### PR TITLE
Rename conflicting methods

### DIFF
--- a/ProposalChanges.md
+++ b/ProposalChanges.md
@@ -130,7 +130,7 @@ In addition, were added:
 * NewClearTextMessage(data []byte, signature []byte) *ClearTextMessage
 * (msg *ClearTextMessage) GetBinary() []byte
 * (msg *ClearTextMessage) GetString() string
-* (msg *ClearTextMessage) GetSignature() []byte
+* (msg *ClearTextMessage) GetBinarySignature() []byte
 * (msg *ClearTextMessage) GetArmored() (string, error)
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To encrypt binary data, reuse the key multiple times, or use more advanced modes
 ```go
 import "github.com/ProtonMail/gopenpgp/constants"
 
-var key = crypto.NewSymmetricKey("my secret password", constants.AES256)
+var key = crypto.NewSymmetricKeyFromToken("my secret password", constants.AES256)
 var message = crypto.NewPlainMessage(data)
 
 // Encrypt data with password

--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -117,8 +117,8 @@ func (keyRing *KeyRing) NewLowMemoryAttachmentProcessor(
 func (keyRing *KeyRing) DecryptAttachment(message *PGPSplitMessage) (*PlainMessage, error) {
 	privKeyEntries := keyRing.entities
 
-	keyReader := bytes.NewReader(message.GetKeyPacket())
-	dataReader := bytes.NewReader(message.GetDataPacket())
+	keyReader := bytes.NewReader(message.GetBinaryKeyPacket())
+	dataReader := bytes.NewReader(message.GetBinaryDataPacket())
 
 	encryptedReader := io.MultiReader(keyReader, dataReader)
 

--- a/crypto/attachment_test.go
+++ b/crypto/attachment_test.go
@@ -64,7 +64,7 @@ func TestAttachmentEncrypt(t *testing.T) {
 		t.Fatal("Expected no error while encrypting attachment, got:", err)
 	}
 
-	pgpMessage := NewPGPMessage(append(encSplit.GetKeyPacket(), encSplit.GetDataPacket()...))
+	pgpMessage := NewPGPMessage(append(encSplit.GetBinaryKeyPacket(), encSplit.GetBinaryDataPacket()...))
 
 	redecData, err := testPrivateKeyRing.Decrypt(pgpMessage, nil, 0)
 	if err != nil {

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -211,13 +211,13 @@ func (msg *PGPMessage) GetArmored() (string, error) {
 	return armor.ArmorWithType(msg.Data, constants.PGPMessageHeader)
 }
 
-// GetDataPacket returns the unarmored binary datapacket as a []byte
-func (msg *PGPSplitMessage) GetDataPacket() []byte {
+// GetBinaryDataPacket returns the unarmored binary datapacket as a []byte
+func (msg *PGPSplitMessage) GetBinaryDataPacket() []byte {
 	return msg.DataPacket
 }
 
-// GetKeyPacket returns the unarmored binary keypacket as a []byte
-func (msg *PGPSplitMessage) GetKeyPacket() []byte {
+// GetBinaryKeyPacket returns the unarmored binary keypacket as a []byte
+func (msg *PGPSplitMessage) GetBinaryKeyPacket() []byte {
 	return msg.KeyPacket
 }
 
@@ -331,14 +331,14 @@ func (msg *ClearTextMessage) GetString() string {
 	return string(msg.Data)
 }
 
-// GetSignature returns the unarmored binary signature as a []byte
-func (msg *ClearTextMessage) GetSignature() []byte {
+// GetBinarySignature returns the unarmored binary signature as a []byte
+func (msg *ClearTextMessage) GetBinarySignature() []byte {
 	return msg.Signature
 }
 
 // GetArmored armors plaintext and signature with the PGP SIGNED MESSAGE armoring
 func (msg *ClearTextMessage) GetArmored() (string, error) {
-	armSignature, err := armor.ArmorWithType(msg.GetSignature(), constants.PGPSignatureHeader)
+	armSignature, err := armor.ArmorWithType(msg.GetBinarySignature(), constants.PGPSignatureHeader)
 	if err != nil {
 		return "", err
 	}

--- a/crypto/symmetrickey.go
+++ b/crypto/symmetrickey.go
@@ -47,12 +47,8 @@ func (symmetricKey *SymmetricKey) GetBase64Key() string {
 }
 
 func NewSymmetricKeyFromToken(passphrase, algo string) *SymmetricKey {
-	return NewSymmetricKey([]byte(passphrase), algo)
-}
-
-func NewSymmetricKey(key []byte, algo string) *SymmetricKey {
 	return &SymmetricKey{
-		Key:  key,
+		Key:  []byte(passphrase),
 		Algo: algo,
 	}
 }
@@ -69,7 +65,12 @@ func newSymmetricKeyFromEncrypted(ek *packet.EncryptedKey) (*SymmetricKey, error
 		return nil, fmt.Errorf("gopenpgp: unsupported cipher function: %v", ek.CipherFunc)
 	}
 
-	return NewSymmetricKey(ek.Key, algo), nil
+	symmetricKey := &SymmetricKey{
+		Key:  ek.Key,
+		Algo: algo,
+	}
+	
+	return symmetricKey, nil
 }
 
 // Encrypt encrypts a PlainMessage to PGPMessage with a SymmetricKey

--- a/helper/cleartext.go
+++ b/helper/cleartext.go
@@ -57,7 +57,7 @@ func VerifyCleartextMessage(keyRing *crypto.KeyRing, armored string, verifyTime 
 	}
 
 	message := crypto.NewPlainMessageFromString(clearTextMessage.GetString())
-	signature := crypto.NewPGPSignature(clearTextMessage.GetSignature())
+	signature := crypto.NewPGPSignature(clearTextMessage.GetBinarySignature())
 	err = keyRing.VerifyDetached(message, signature, verifyTime)
 	if err != nil {
 		return "", err

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -203,7 +203,7 @@ func EncryptSignAttachment(
 		return nil, nil, nil, err
 	}
 
-	return packets.GetKeyPacket(), packets.GetDataPacket(), signatureObj.GetBinary(), nil
+	return packets.GetBinaryKeyPacket(), packets.GetBinaryDataPacket(), signatureObj.GetBinary(), nil
 }
 
 // DecryptVerifyAttachment decrypts and verifies an attachment split into the keyPacket, dataPacket


### PR DESCRIPTION
Closes https://github.com/ProtonMail/gopenpgp/issues/18

Fix compilation issues on Android, by renaming some methods that get automatically generated by Java.