### PR TITLE
Hotfix to prevent use-after-free bug on iOS

### DIFF
--- a/crypto/message.go
+++ b/crypto/message.go
@@ -75,8 +75,12 @@ func NewPlainMessageFromString(text string) *PlainMessage {
 
 // NewPGPMessage generates a new PGPMessage from the unarmored binary data.
 func NewPGPMessage(data []byte) *PGPMessage {
+	// Hotfix: Additional copy to prevent Swift's garbage collector from freeing
+	// the memory containing the message, when used with Gomobile on iOS
+	tmp := make([]byte, len(data))
+	copy(tmp, data)
 	return &PGPMessage{
-		Data: data,
+		Data: tmp,
 	}
 }
 


### PR DESCRIPTION
The NewPGPMessage() function is currently broken when GopenPGP is used with Gomobile on iOS as the memory pointed to in the PGPMessage struct is erroneously freed by the Swift garbage collector. This error is discussed in golang/go#33745 (additional discussion in mssun/passforios#289).

This hotfix copies the encrypted data into memory controlled by Go's garbage collector in the NewPGPMessage() function to prevent issues caused by the Swift garbage collector's erroneous free and restores the functionality of NewPGPMessage().