### PR TITLE
Fix TestMultipleKeyMessageEncryption

### DIFF
--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -3,7 +3,6 @@ package crypto
 import (
 	"bytes"
 	"encoding/base64"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -153,19 +152,27 @@ func TestMultipleKeyMessageEncryption(t *testing.T) {
 		t.Fatal("Expected no error when encrypting, got:", err)
 	}
 
-	numKeyPackets := 0
+	// Test that ciphertext data contains first three Encrypted Key Packets
+	// (tag 1) followed by a single symmetrically encrypted data packet (tag 18)
+	var p packet.Packet
 	packets := packet.NewReader(bytes.NewReader(ciphertext.Data))
-	for {
-		var p packet.Packet
-		if p, err = packets.Next(); err == io.EOF {
+	for i := 0; i < 3; i++ {
+		if p, err = packets.Next(); err != nil {
+			t.Fatal(err.Error())
 			break
 		}
-		if _, ok := p.(*packet.EncryptedKey); ok {
-			numKeyPackets++
+		if _, ok := p.(*packet.EncryptedKey); !ok {
+			t.Fatalf("Expected Encrypted Key packet, got %T", p)
 		}
 	}
-	assert.Exactly(t, 3, numKeyPackets)
+	if p, err = packets.Next(); err != nil {
+		t.Fatal(err.Error())
+	}
+	if _, ok := p.(*packet.SymmetricallyEncrypted); !ok {
+		t.Fatalf("Expected Symmetrically Encrypted Data packet, got %T", p)
+	}
 
+	// Decrypt message and verify correctness
 	decrypted, err := keyRingTestPrivate.Decrypt(ciphertext, keyRingTestPublic, GetUnixTime())
 	if err != nil {
 		t.Fatal("Expected no error when decrypting, got:", err)

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -156,20 +156,19 @@ func TestMultipleKeyMessageEncryption(t *testing.T) {
 	// (tag 1) followed by a single symmetrically encrypted data packet (tag 18)
 	var p packet.Packet
 	packets := packet.NewReader(bytes.NewReader(ciphertext.Data))
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if p, err = packets.Next(); err != nil {
 			t.Fatal(err.Error())
-			break
 		}
-		if _, ok := p.(*packet.EncryptedKey); !ok {
-			t.Fatalf("Expected Encrypted Key packet, got %T", p)
+		if i < 3 {
+			if _, ok := p.(*packet.EncryptedKey); !ok {
+				t.Fatalf("Expected Encrypted Key packet, got %T", p)
+			}
+		} else {
+			if _, ok := p.(*packet.SymmetricallyEncrypted); !ok {
+				t.Fatalf("Expected Symmetrically Encrypted Data packet, got %T", p)
+			}
 		}
-	}
-	if p, err = packets.Next(); err != nil {
-		t.Fatal(err.Error())
-	}
-	if _, ok := p.(*packet.SymmetricallyEncrypted); !ok {
-		t.Fatalf("Expected Symmetrically Encrypted Data packet, got %T", p)
 	}
 
 	// Decrypt message and verify correctness


### PR DESCRIPTION
When ciphertext data ends with a Symmetrically Encrypted Packet, the next subsequent call to `packet.Next()` after this packet tries to read an OpenPGP packet from the reader embedded in the Symmetrically Encrypted Packet, causing undesirable behaviour.

This tests now only checks (with 4 calls to `packet.Next()`) that there are 3 Encrypted Key Packets and one Symmetrically Encrypted Data Packet, plus correctness of decryption.