### PR TITLE
doc: update README to use valid go.mod example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ crypto library](https://github.com/ProtonMail/crypto).
 To use this library using [Go Modules](https://github.com/golang/go/wiki/Modules) just edit your
 `go.mod` configuration to contain:
 ```gomod
-require {
+require (
     ...
     github.com/ProtonMail/gopenpgp/v2 v2.0.0
-}
+)
 
 replace golang.org/x/crypto => github.com/ProtonMail/crypto v0.0.0-20191122234321-e77a1f03baa0
 ```


### PR DESCRIPTION
This commit simply uses parenthesis in the example `go.mod` `require` block since curly braces are illegal there. If a potential user copies the text as the basis for starting a new `go.mod`, they'll get cryptic compilation errors.