### PR TITLE
Fix symmetric session key test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.1] - 2020-05-01
 ### Security
 - Updated underlying crypto library
 - Improved memory zeroing in helpers
 
 ### Fixed
-- Fixed test `TestMultipleKeyMessageEncryption`
 - Fixed garbage collection issues when compiled on gomobile, by copying byte slices
 - Password encrypted binary files now have the correct flags
 - Fixed missing space in `Hash` header of cleartext messages
+- Fixed tests `TestMultipleKeyMessageEncryption` and `TestSymmetricKeyPacket`
 
 ## Changed
 - Providing empty passphrase does no longer throw an error when unlocking an unencrypted private key

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use this library using [Go Modules](https://github.com/golang/go/wiki/Modules
 ```gomod
 require (
     ...
-    github.com/ProtonMail/gopenpgp/v2 v2.0.0
+    github.com/ProtonMail/gopenpgp/v2 v2.0.1
 )
 
 replace golang.org/x/crypto => github.com/ProtonMail/crypto v0.0.0-20200416114516-1fa7f403fb9c

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,7 +3,7 @@ package constants
 
 // Constants for armored data.
 const (
-	ArmorHeaderVersion = "GopenPGP 2.0.0"
+	ArmorHeaderVersion = "GopenPGP 2.0.1"
 	ArmorHeaderComment = "https://gopenpgp.org"
 	PGPMessageHeader   = "PGP MESSAGE"
 	PGPSignatureHeader = "PGP SIGNATURE"

--- a/crypto/password.go
+++ b/crypto/password.go
@@ -70,7 +70,7 @@ func DecryptSessionKeyWithPassword(keyPacket, password []byte) (*SessionKey, err
 		}
 	}
 
-	return nil, errors.New("gopenpgp: password incorrect")
+	return nil, errors.New("gopenpgp: unable to decrypt any packet")
 }
 
 // EncryptSessionKeyWithPassword encrypts the session key with the password and

--- a/crypto/sessionkey_test.go
+++ b/crypto/sessionkey_test.go
@@ -52,14 +52,17 @@ func TestSymmetricKeyPacket(t *testing.T) {
 		t.Fatal("Expected no error while generating key packet, got:", err)
 	}
 
-	_, err = DecryptSessionKeyWithPassword(keyPacket, []byte("Wrong password"))
-	assert.EqualError(t, err, "gopenpgp: password incorrect")
+	wrongSymmetricKey, err := DecryptSessionKeyWithPassword(keyPacket, []byte("Wrong password"))
+	if err != nil {
+		assert.EqualError(t, err, "gopenpgp: unable to decrypt any packet")
+	} else {
+		assert.NotEqual(t, testSessionKey, wrongSymmetricKey)
+	}
 
 	outputSymmetricKey, err := DecryptSessionKeyWithPassword(keyPacket, password)
 	if err != nil {
 		t.Fatal("Expected no error while decrypting key packet, got:", err)
 	}
-
 	assert.Exactly(t, testSessionKey, outputSymmetricKey)
 }
 


### PR DESCRIPTION
Fix symmetric session key test failing 1/256 times due to misuse of algorithm byte as checksum