### PR TITLE
Implement GetArmoredWithCustomHeaders

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - gochecknoglobals  # Checks that no globals are present in Go code [fast: true, auto-fix: false]
     - gochecknoinits    # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
     - golint            # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true, auto-fix: false]
+    - goerr113          # Golang linter to check the errors handling expressions [fast: true, auto-fix: false]
     - gomnd             # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
     - lll               # Reports long lines [fast: true, auto-fix: false]
     - testpackage       # Makes you use a separate _test package [fast: true, auto-fix: false]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Key Armoring with custom headers
+```go
+(key *Key) ArmorWithCustomHeaders(comment, version string) (string, error)
+(key *Key) GetArmoredPublicKeyWithCustomHeaders(comment, version string) (string, error)
+```
+- Message armoring with custom headers
+```go
+(msg *PGPMessage) GetArmoredWithCustomHeaders(comment, version string) (string, error)
+```
+
+### Changed
+- Improved key and message armoring testing
+
+### Fixed
+- Public key armoring headers
+
 ## [2.0.1] - 2020-05-01
 ### Security
 - Updated underlying crypto library

--- a/armor/armor.go
+++ b/armor/armor.go
@@ -42,7 +42,7 @@ func ArmorWithTypeAndCustomHeaders(input []byte, armorType, version, comment str
 	return armorWithTypeAndHeaders(input, armorType, headers)
 }
 
-// Unarmor unarmors an armored key.
+// Unarmor unarmors an armored input into a byte array.
 func Unarmor(input string) ([]byte, error) {
 	b, err := internal.Unarmor(input)
 	if err != nil {

--- a/armor/armor.go
+++ b/armor/armor.go
@@ -26,9 +26,35 @@ func ArmorWithTypeBuffered(w io.Writer, armorType string) (io.WriteCloser, error
 
 // ArmorWithType armors input with the given armorType.
 func ArmorWithType(input []byte, armorType string) (string, error) {
+	return armorWithTypeAndHeaders(input, armorType, internal.ArmorHeaders)
+}
+
+// ArmorWithTypeAndCustomHeaders armors input with the given armorType and
+// headers.
+func ArmorWithTypeAndCustomHeaders(input []byte, armorType, version, comment string) (string, error) {
+	headers := make(map[string]string)
+	if version != "" {
+		headers["Version"] = version
+	}
+	if comment != "" {
+		headers["Comment"] = comment
+	}
+	return armorWithTypeAndHeaders(input, armorType, headers)
+}
+
+// Unarmor unarmors an armored key.
+func Unarmor(input string) ([]byte, error) {
+	b, err := internal.Unarmor(input)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(b.Body)
+}
+
+func armorWithTypeAndHeaders(input []byte, armorType string, headers map[string]string) (string, error) {
 	var b bytes.Buffer
 
-	w, err := armor.Encode(&b, armorType, internal.ArmorHeaders)
+	w, err := armor.Encode(&b, armorType, headers)
 
 	if err != nil {
 		return "", err
@@ -40,13 +66,4 @@ func ArmorWithType(input []byte, armorType string) (string, error) {
 		return "", err
 	}
 	return b.String(), nil
-}
-
-// Unarmor unarmors an armored key.
-func Unarmor(input string) ([]byte, error) {
-	b, err := internal.Unarmor(input)
-	if err != nil {
-		return nil, err
-	}
-	return ioutil.ReadAll(b.Body)
 }

--- a/crypto/keyring_test.go
+++ b/crypto/keyring_test.go
@@ -12,6 +12,7 @@ import (
 
 var testSymmetricKey []byte
 
+// Password for key in testdata/keyring_privateKeyLegacy: "123"
 // Corresponding key in testdata/keyring_privateKey.
 var testMailboxPassword = []byte("apple")
 

--- a/crypto/keyring_test.go
+++ b/crypto/keyring_test.go
@@ -12,7 +12,7 @@ import (
 
 var testSymmetricKey []byte
 
-// Password for key in testdata/keyring_privateKeyLegacy: "123"
+// Password for key in testdata/keyring_privateKeyLegacy: "123".
 // Corresponding key in testdata/keyring_privateKey.
 var testMailboxPassword = []byte("apple")
 

--- a/crypto/keyring_test.go
+++ b/crypto/keyring_test.go
@@ -12,11 +12,8 @@ import (
 
 var testSymmetricKey []byte
 
-// Corresponding key in testdata/keyring_privateKey
+// Corresponding key in testdata/keyring_privateKey.
 var testMailboxPassword = []byte("apple")
-
-// Corresponding key in testdata/keyring_privateKeyLegacy
-// const testMailboxPasswordLegacy = [][]byte{ []byte("123") }
 
 var (
 	keyRingTestPrivate  *KeyRing

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -218,8 +218,7 @@ func (msg *PGPMessage) GetArmored() (string, error) {
 }
 
 // GetArmoredWithCustomHeaders returns the armored message as a string, with
-// the given headers. If comment or version are empty, then no header is
-// displayed.
+// the given headers. Empty parameters are omitted from the headers.
 func (msg *PGPMessage) GetArmoredWithCustomHeaders(comment, version string) (string, error) {
 	return armor.ArmorWithTypeAndCustomHeaders(msg.Data, constants.PGPMessageHeader, version, comment)
 }

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -48,7 +48,7 @@ type PGPSplitMessage struct {
 }
 
 // A ClearTextMessage is a signed but not encrypted PGP message,
-// i.e. the ones beginning with -----BEGIN PGP SIGNED MESSAGE-----
+// i.e. the ones beginning with -----BEGIN PGP SIGNED MESSAGE-----.
 type ClearTextMessage struct {
 	Data      []byte
 	Signature []byte

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -217,6 +217,13 @@ func (msg *PGPMessage) GetArmored() (string, error) {
 	return armor.ArmorWithType(msg.Data, constants.PGPMessageHeader)
 }
 
+// GetArmoredWithCustomHeaders returns the armored message as a string, with
+// the given headers. If comment or version are empty, then no header is
+// displayed.
+func (msg *PGPMessage) GetArmoredWithCustomHeaders(comment, version string) (string, error) {
+	return armor.ArmorWithTypeAndCustomHeaders(msg.Data, constants.PGPMessageHeader, version, comment)
+}
+
 // GetBinaryDataPacket returns the unarmored binary datapacket as a []byte.
 func (msg *PGPSplitMessage) GetBinaryDataPacket() []byte {
 	return msg.DataPacket

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -178,3 +178,38 @@ func TestMultipleKeyMessageEncryption(t *testing.T) {
 	}
 	assert.Exactly(t, message.GetString(), decrypted.GetString())
 }
+
+func TestMessageGetArmoredWithCustomHeaders(t *testing.T) {
+	var message = NewPlainMessageFromString("plain text")
+
+	ciphertext, err := keyRingTestPublic.Encrypt(message, keyRingTestPrivate)
+	if err != nil {
+		t.Fatal("Expected no error when encrypting, got:", err)
+	}
+	comment := "User-defined comment"
+	version := "User-defined version"
+	armored, err := ciphertext.GetArmoredWithCustomHeaders(comment, version)
+	if err != nil {
+		t.Fatal("Could not armor the ciphertext:", err)
+	}
+
+	assert.Contains(t, armored, comment)
+}
+
+func TestMessageGetArmoredWithEmptyHeaders(t *testing.T) {
+	var message = NewPlainMessageFromString("plain text")
+
+	ciphertext, err := keyRingTestPublic.Encrypt(message, keyRingTestPrivate)
+	if err != nil {
+		t.Fatal("Expected no error when encrypting, got:", err)
+	}
+	comment := ""
+	version := ""
+	armored, err := ciphertext.GetArmoredWithCustomHeaders(comment, version)
+	if err != nil {
+		t.Fatal("Could not armor the ciphertext:", err)
+	}
+
+	assert.NotContains(t, armored, "Version")
+	assert.NotContains(t, armored, "Comment")
+}

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -193,7 +193,8 @@ func TestMessageGetArmoredWithCustomHeaders(t *testing.T) {
 		t.Fatal("Could not armor the ciphertext:", err)
 	}
 
-	assert.Contains(t, armored, comment)
+	assert.Contains(t, armored, "Comment: "+comment)
+	assert.Contains(t, armored, "Version: "+version)
 }
 
 func TestMessageGetArmoredWithEmptyHeaders(t *testing.T) {

--- a/crypto/mime_test.go
+++ b/crypto/mime_test.go
@@ -6,10 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Corresponding key in testdata/mime_privateKey
+// Corresponding key in testdata/mime_privateKey.
 var MIMEKeyPassword = []byte("test")
 
-// define call back interface
 type Callbacks struct {
 	Testing *testing.T
 }

--- a/helper/base_test.go
+++ b/helper/base_test.go
@@ -20,7 +20,7 @@ func readTestFile(name string, trimNewlines bool) string {
 	return string(data)
 }
 
-// Corresponding key in ../crypto/testdata/keyring_privateKey
+// Corresponding key in ../crypto/testdata/keyring_privateKey.
 var testMailboxPassword = []byte("apple")
 
 func init() {


### PR DESCRIPTION
Closes #38 

Also, `ArmorWithTypeAndCustomHeaders` can be reused by other PGP armoured objects.