### PR TITLE
Add method to make private key objects public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ EncryptBinaryMessageArmored(key string, data []byte) (string, error)
 DecryptBinaryMessageArmored(privateKey string, passphrase []byte, ciphertext string) ([]byte, error)
 ```
 
+- Method to derive a public key object from a private key
+```go
+(key *Key) ToPublic() (publicKey *Key, err error) 
+```
+
 ### Changed
 - Improved key and message armoring testing
 - `EncryptSessionKey` now creates encrypted key packets for each valid encryption key in the provided keyring. 

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -359,6 +359,21 @@ func (key *Key) GetEntity() *openpgp.Entity {
 	return key.entity
 }
 
+// ToPublic returns the corresponding public key of the given private key.
+func (key *Key) ToPublic() (publicKey *Key, err error) {
+	if !key.IsPrivate() {
+		return nil, errors.New("gopenpgp: key is already public")
+	}
+
+	publicKey, err = key.Copy()
+	if err != nil {
+		return nil, err
+	}
+
+	publicKey.ClearPrivateParams()
+	return
+}
+
 // --- Internal methods
 
 // getSHA256FingerprintBytes computes the SHA256 fingerprint of a public key

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -389,3 +389,19 @@ func TestGetEntity(t *testing.T) {
 	assert.True(t, entity.PrimaryIdentity().SelfSignature.FlagsValid)
 	assert.IsType(t, &openpgp.Entity{}, entity)
 }
+
+func TestToPublic(t *testing.T) {
+	privateKey, err := NewKeyFromArmored(readTestFile("keyring_privateKey", false))
+	if err != nil {
+		t.Fatal("Cannot unarmor key:", err)
+	}
+	assert.True(t, privateKey.IsPrivate())
+
+	publicKey, err := privateKey.ToPublic()
+	if err != nil {
+		t.Fatal("Cannot make key public:", err)
+	}
+
+	assert.False(t, publicKey.IsPrivate())
+	assert.True(t, privateKey.IsPrivate())
+}


### PR DESCRIPTION
Adding Method to make private key objects public
```go
(key *Key) ToPublic() (publicKey *Key, err error)
```