### PR TITLE
Convert private to public keys in helpers

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -61,6 +61,12 @@ func EncryptSignMessageArmored(
 	if publicKeyObj, err = crypto.NewKeyFromArmored(publicKey); err != nil {
 		return "", err
 	}
+	if publicKeyObj.IsPrivate() {
+		publicKeyObj, err = publicKeyObj.ToPublic()
+		if err != nil {
+			return "", err
+		}
+	}
 
 	if publicKeyRing, err = crypto.NewKeyRing(publicKeyObj); err != nil {
 		return "", err
@@ -118,6 +124,12 @@ func DecryptVerifyMessageArmored(
 	if publicKeyObj, err = crypto.NewKeyFromArmored(publicKey); err != nil {
 		return "", err
 	}
+	if publicKeyObj.IsPrivate() {
+		publicKeyObj, err = publicKeyObj.ToPublic()
+		if err != nil {
+			return "", err
+		}
+	}
 
 	if publicKeyRing, err = crypto.NewKeyRing(publicKeyObj); err != nil {
 		return "", err
@@ -165,6 +177,12 @@ func DecryptVerifyAttachment(
 
 	if publicKeyObj, err = crypto.NewKeyFromArmored(publicKey); err != nil {
 		return nil, err
+	}
+	if publicKeyObj.IsPrivate() {
+		publicKeyObj, err = publicKeyObj.ToPublic()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if publicKeyRing, err = crypto.NewKeyRing(publicKeyObj); err != nil {
@@ -219,6 +237,12 @@ func DecryptBinaryMessageArmored(privateKey string, passphrase []byte, ciphertex
 
 func encryptMessageArmored(key string, message *crypto.PlainMessage) (string, error) {
 	publicKey, err := crypto.NewKeyFromArmored(key)
+	if publicKey.IsPrivate() {
+		publicKey, err = publicKey.ToPublic()
+		if err != nil {
+			return "", err
+		}
+	}
 
 	if err != nil {
 		return "", err

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -53,7 +53,7 @@ func TestArmoredTextMessageEncryptionVerification(t *testing.T) {
 	var plaintext = "Secret message"
 
 	armored, err := EncryptSignMessageArmored(
-		readTestFile("keyring_publicKey", false),
+		readTestFile("keyring_privateKey", false),
 		readTestFile("keyring_privateKey", false),
 		testMailboxPassword, // Password defined in base_test
 		plaintext,
@@ -65,7 +65,7 @@ func TestArmoredTextMessageEncryptionVerification(t *testing.T) {
 	assert.Exactly(t, true, crypto.IsPGPMessage(armored))
 
 	_, err = DecryptVerifyMessageArmored(
-		readTestFile("mime_publicKey", false), // Wrong public key
+		readTestFile("mime_privateKey", false), // Wrong public key
 		readTestFile("keyring_privateKey", false),
 		testMailboxPassword, // Password defined in base_test
 		armored,
@@ -73,7 +73,7 @@ func TestArmoredTextMessageEncryptionVerification(t *testing.T) {
 	assert.EqualError(t, err, "Signature Verification Error: No matching signature")
 
 	decrypted, err := DecryptVerifyMessageArmored(
-		readTestFile("keyring_publicKey", false),
+		readTestFile("keyring_privateKey", false),
 		readTestFile("keyring_privateKey", false),
 		testMailboxPassword, // Password defined in base_test
 		armored,
@@ -90,7 +90,7 @@ func TestAttachmentEncryptionVerification(t *testing.T) {
 	var attachment = []byte("Secret file\r\nRoot password:hunter2")
 
 	keyPacket, dataPacket, signature, err := EncryptSignAttachment(
-		readTestFile("keyring_publicKey", false),
+		readTestFile("keyring_privateKey", false),
 		readTestFile("keyring_privateKey", false),
 		testMailboxPassword, // Password defined in base_test
 		"password.txt",
@@ -107,7 +107,7 @@ func TestAttachmentEncryptionVerification(t *testing.T) {
 	}
 
 	_, err = DecryptVerifyAttachment(
-		readTestFile("mime_publicKey", false), // Wrong public key
+		readTestFile("mime_privateKey", false), // Wrong public key
 		readTestFile("keyring_privateKey", false),
 		testMailboxPassword, // Password defined in base_test
 		keyPacket,
@@ -117,7 +117,7 @@ func TestAttachmentEncryptionVerification(t *testing.T) {
 	assert.EqualError(t, err, "gopenpgp: unable to verify attachment")
 
 	decrypted, err := DecryptVerifyAttachment(
-		readTestFile("keyring_publicKey", false),
+		readTestFile("keyring_privateKey", false),
 		readTestFile("keyring_privateKey", false),
 		testMailboxPassword, // Password defined in base_test
 		keyPacket,
@@ -134,7 +134,7 @@ func TestAttachmentEncryptionVerification(t *testing.T) {
 func TestArmoredBinaryMessageEncryption(t *testing.T) {
 	plainData := []byte("Secret message")
 
-	armored, err := EncryptBinaryMessageArmored(readTestFile("keyring_publicKey", false), plainData)
+	armored, err := EncryptBinaryMessageArmored(readTestFile("keyring_privateKey", false), plainData)
 
 	if err != nil {
 		t.Fatal("Expected no error when encrypting, got:", err)

--- a/helper/sign_attachment.go
+++ b/helper/sign_attachment.go
@@ -21,6 +21,12 @@ func EncryptSignAttachment(
 	if publicKeyObj, err = crypto.NewKeyFromArmored(publicKey); err != nil {
 		return nil, nil, nil, err
 	}
+	if publicKeyObj.IsPrivate() {
+		publicKeyObj, err = publicKeyObj.ToPublic()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
 
 	if publicKeyRing, err = crypto.NewKeyRing(publicKeyObj); err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
Fixes a bug that prevented encryption and verification when using locked private keys as public