### PR TITLE
Add filename and time properties to message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,21 @@ EncryptSignArmoredDetachedMobile(
 ) (wrappedTuple *EncryptSignArmoredDetachedMobileResult, err error)
 ```
 
+- `NewPlainMessageFromFile` Function to create new `PlainMessage`s with a filename:
+```go
+NewPlainMessageFromFile(data []byte, filename string, modTime int) *PlainMessage
+```
+
+- `GetFilename` to get the filename from a message:
+```go 
+(msg *PlainMessage) GetFilename() string
+```
+
+- `GetModTime` to get the modification time of a file
+```go 
+(msg *PlainMessage) GetModTime() uint32
+```
+
 ### Changed
 - Improved key and message armoring testing
 - `EncryptSessionKey` now creates encrypted key packets for each valid encryption key in the provided keyring. 
@@ -80,6 +95,8 @@ EncryptSignArmoredDetachedMobile(
 - Use aes256 cipher for password-encrypted messages.
 - The helpers `EncryptSignMessageArmored`, `DecryptVerifyMessageArmored`, `DecryptVerifyAttachment`, and`DecryptBinaryMessageArmored`
     now accept private keys as public keys and perform automatic casting if the keys are locked.
+- The `PlainMessage` struct now contains the fields `filename` (string) and `time` (uint32)
+- All the Decrypt* functions return the filename, type, and time specified in the encrypted message
 
 ### Fixed
 - Public key armoring headers

--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"runtime"
 	"sync"
+	"time"
 
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/packet"
@@ -52,7 +53,7 @@ func (ap *AttachmentProcessor) Finish() (*PGPSplitMessage, error) {
 // newAttachmentProcessor creates an AttachmentProcessor which can be used to encrypt
 // a file. It takes an estimatedSize and fileName as hints about the file.
 func (keyRing *KeyRing) newAttachmentProcessor(
-	estimatedSize int, fileName string, garbageCollector int,
+	estimatedSize int, filename string, isBinary bool, modTime uint32, garbageCollector int,
 ) (*AttachmentProcessor, error) {
 	attachmentProc := &AttachmentProcessor{}
 	// You could also add these one at a time if needed.
@@ -60,7 +61,9 @@ func (keyRing *KeyRing) newAttachmentProcessor(
 	attachmentProc.garbageCollector = garbageCollector
 
 	hints := &openpgp.FileHints{
-		FileName: fileName,
+		FileName: filename,
+		IsBinary: isBinary,
+		ModTime:  time.Unix(int64(modTime), 0),
 	}
 
 	config := &packet.Config{
@@ -93,11 +96,22 @@ func (keyRing *KeyRing) newAttachmentProcessor(
 	return attachmentProc, nil
 }
 
-// EncryptAttachment encrypts a file given a PlainMessage and a fileName.
+// EncryptAttachment encrypts a file given a PlainMessage and a filename.
+// If given a filename it will override the information in the PlainMessage object.
 // Returns a PGPSplitMessage containing a session key packet and symmetrically encrypted data.
 // Specifically designed for attachments rather than text messages.
-func (keyRing *KeyRing) EncryptAttachment(message *PlainMessage, fileName string) (*PGPSplitMessage, error) {
-	ap, err := keyRing.newAttachmentProcessor(len(message.GetBinary()), fileName, -1)
+func (keyRing *KeyRing) EncryptAttachment(message *PlainMessage, filename string) (*PGPSplitMessage, error) {
+	if filename == "" {
+		filename = message.filename
+	}
+
+	ap, err := keyRing.newAttachmentProcessor(
+		len(message.GetBinary()),
+		filename,
+		message.IsBinary(),
+		message.GetTime(),
+		-1,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -114,9 +128,9 @@ func (keyRing *KeyRing) EncryptAttachment(message *PlainMessage, fileName string
 // file. It is optimized for low-memory environments and collects garbage every
 // megabyte.
 func (keyRing *KeyRing) NewLowMemoryAttachmentProcessor(
-	estimatedSize int, fileName string,
+	estimatedSize int, filename string,
 ) (*AttachmentProcessor, error) {
-	return keyRing.newAttachmentProcessor(estimatedSize, fileName, 1<<20)
+	return keyRing.newAttachmentProcessor(estimatedSize, filename, true, 0, 1<<20)
 }
 
 // DecryptAttachment takes a PGPSplitMessage, containing a session key packet and symmetrically encrypted data
@@ -143,5 +157,10 @@ func (keyRing *KeyRing) DecryptAttachment(message *PGPSplitMessage) (*PlainMessa
 		return nil, err
 	}
 
-	return NewPlainMessage(b), nil
+	return &PlainMessage{
+		Data:     b,
+		TextType: !md.LiteralData.IsBinary,
+		filename: md.LiteralData.FileName,
+		time:     md.LiteralData.Time,
+	}, nil
 }

--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -130,7 +130,7 @@ func (keyRing *KeyRing) EncryptAttachment(message *PlainMessage, filename string
 func (keyRing *KeyRing) NewLowMemoryAttachmentProcessor(
 	estimatedSize int, filename string,
 ) (*AttachmentProcessor, error) {
-	return keyRing.newAttachmentProcessor(estimatedSize, filename, true, 0, 1<<20)
+	return keyRing.newAttachmentProcessor(estimatedSize, filename, true, uint32(GetUnixTime()), 1<<20)
 }
 
 // DecryptAttachment takes a PGPSplitMessage, containing a session key packet and symmetrically encrypted data

--- a/crypto/attachment_test.go
+++ b/crypto/attachment_test.go
@@ -42,9 +42,9 @@ func TestAttachmentSetKey(t *testing.T) {
 
 func TestAttachmentEncryptDecrypt(t *testing.T) {
 	var testAttachmentCleartext = "cc,\ndille."
-	var message = NewPlainMessage([]byte(testAttachmentCleartext))
+	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 0)
 
-	encSplit, err := keyRingTestPrivate.EncryptAttachment(message, "s.txt")
+	encSplit, err := keyRingTestPrivate.EncryptAttachment(message, "")
 	if err != nil {
 		t.Fatal("Expected no error while encrypting attachment, got:", err)
 	}
@@ -59,9 +59,9 @@ func TestAttachmentEncryptDecrypt(t *testing.T) {
 
 func TestAttachmentEncrypt(t *testing.T) {
 	var testAttachmentCleartext = "cc,\ndille."
-	var message = NewPlainMessage([]byte(testAttachmentCleartext))
+	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 0)
 
-	encSplit, err := keyRingTestPrivate.EncryptAttachment(message, "s.txt")
+	encSplit, err := keyRingTestPrivate.EncryptAttachment(message, "")
 	if err != nil {
 		t.Fatal("Expected no error while encrypting attachment, got:", err)
 	}
@@ -78,7 +78,7 @@ func TestAttachmentEncrypt(t *testing.T) {
 
 func TestAttachmentDecrypt(t *testing.T) {
 	var testAttachmentCleartext = "cc,\ndille."
-	var message = NewPlainMessage([]byte(testAttachmentCleartext))
+	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 0)
 
 	encrypted, err := keyRingTestPrivate.Encrypt(message, nil)
 	if err != nil {

--- a/crypto/attachment_test.go
+++ b/crypto/attachment_test.go
@@ -42,7 +42,7 @@ func TestAttachmentSetKey(t *testing.T) {
 
 func TestAttachmentEncryptDecrypt(t *testing.T) {
 	var testAttachmentCleartext = "cc,\ndille."
-	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 0)
+	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 1602518992)
 
 	encSplit, err := keyRingTestPrivate.EncryptAttachment(message, "")
 	if err != nil {
@@ -59,7 +59,7 @@ func TestAttachmentEncryptDecrypt(t *testing.T) {
 
 func TestAttachmentEncrypt(t *testing.T) {
 	var testAttachmentCleartext = "cc,\ndille."
-	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 0)
+	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 1602518992)
 
 	encSplit, err := keyRingTestPrivate.EncryptAttachment(message, "")
 	if err != nil {
@@ -78,7 +78,7 @@ func TestAttachmentEncrypt(t *testing.T) {
 
 func TestAttachmentDecrypt(t *testing.T) {
 	var testAttachmentCleartext = "cc,\ndille."
-	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 0)
+	var message = NewPlainMessageFromFile([]byte(testAttachmentCleartext), "test.txt", 1602518992)
 
 	encrypted, err := keyRingTestPrivate.Encrypt(message, nil)
 	if err != nil {

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -24,8 +24,12 @@ import (
 type PlainMessage struct {
 	// The content of the message
 	Data []byte
-	// if the content is text or binary
+	// If the content is text or binary
 	TextType bool
+	// The file's latest modification time
+	time uint32
+	// The encrypted message's filename
+	filename string
 }
 
 // PGPMessage stores a PGP-encrypted message.
@@ -62,6 +66,18 @@ func NewPlainMessage(data []byte) *PlainMessage {
 	return &PlainMessage{
 		Data:     clone(data),
 		TextType: false,
+	}
+}
+
+// NewPlainMessageFromFile generates a new binary PlainMessage ready for encryption,
+// signature, or verification from the unencrypted binary data.
+// It assigns a filename and a modification time.
+func NewPlainMessageFromFile(data []byte, filename string, time uint32) *PlainMessage {
+	return &PlainMessage{
+		Data:     clone(data),
+		TextType: false,
+		filename: filename,
+		time:     time,
 	}
 }
 
@@ -199,6 +215,16 @@ func (msg *PlainMessage) IsText() bool {
 // IsBinary returns whether the message is a binary message.
 func (msg *PlainMessage) IsBinary() bool {
 	return !msg.TextType
+}
+
+// GetFilename returns the file name of the message as a string.
+func (msg *PlainMessage) GetFilename() string {
+	return msg.filename
+}
+
+// GetTime returns the modification time of a file (if provided in the ciphertext).
+func (msg *PlainMessage) GetTime() uint32 {
+	return msg.time
 }
 
 // GetBinary returns the unarmored binary content of the message as a []byte.

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -66,6 +66,7 @@ func NewPlainMessage(data []byte) *PlainMessage {
 	return &PlainMessage{
 		Data:     clone(data),
 		TextType: false,
+		time:     uint32(GetUnixTime()),
 	}
 }
 
@@ -87,6 +88,7 @@ func NewPlainMessageFromString(text string) *PlainMessage {
 	return &PlainMessage{
 		Data:     []byte(text),
 		TextType: true,
+		time:     uint32(GetUnixTime()),
 	}
 }
 

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -139,7 +139,13 @@ func (sk *SessionKey) Encrypt(message *PlainMessage) ([]byte, error) {
 		}
 	}
 
-	encryptWriter, err = packet.SerializeLiteral(encryptWriter, message.IsBinary(), "", 0)
+	encryptWriter, err = packet.SerializeLiteral(
+		encryptWriter,
+		message.IsBinary(),
+		message.GetFilename(),
+		message.GetTime(),
+	)
+
 	if err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: unable to serialize")
 	}
@@ -210,7 +216,12 @@ func (sk *SessionKey) Decrypt(dataPacket []byte) (*PlainMessage, error) {
 		return nil, err
 	}
 
-	return NewPlainMessage(messageBuf.Bytes()), nil
+	return &PlainMessage{
+		Data:     messageBuf.Bytes(),
+		TextType: !md.LiteralData.IsBinary,
+		filename: md.LiteralData.FileName,
+		time:     md.LiteralData.Time,
+	}, err
 }
 
 func (sk *SessionKey) checkSize() error {

--- a/helper/mobile.go
+++ b/helper/mobile.go
@@ -61,7 +61,7 @@ func DecryptAttachment(keyPacket []byte, dataPacket []byte, keyRing *crypto.KeyR
 // encrypted data. Specifically designed for attachments rather than text
 // messages.
 func EncryptAttachment(plainData []byte, filename string, keyRing *crypto.KeyRing) (*crypto.PGPSplitMessage, error) {
-	plainMessage := crypto.NewPlainMessageFromFile(plainData, filename, 0)
+	plainMessage := crypto.NewPlainMessageFromFile(plainData, filename, uint32(crypto.GetUnixTime()))
 	decrypted, err := keyRing.EncryptAttachment(plainMessage, "")
 	if err != nil {
 		return nil, err

--- a/helper/mobile.go
+++ b/helper/mobile.go
@@ -60,9 +60,9 @@ func DecryptAttachment(keyPacket []byte, dataPacket []byte, keyRing *crypto.KeyR
 // Returns a PGPSplitMessage containing a session key packet and symmetrically
 // encrypted data. Specifically designed for attachments rather than text
 // messages.
-func EncryptAttachment(plainData []byte, fileName string, keyRing *crypto.KeyRing) (*crypto.PGPSplitMessage, error) {
-	plainMessage := crypto.NewPlainMessage(plainData)
-	decrypted, err := keyRing.EncryptAttachment(plainMessage, fileName)
+func EncryptAttachment(plainData []byte, filename string, keyRing *crypto.KeyRing) (*crypto.PGPSplitMessage, error) {
+	plainMessage := crypto.NewPlainMessageFromFile(plainData, filename, 0)
+	decrypted, err := keyRing.EncryptAttachment(plainMessage, "")
 	if err != nil {
 		return nil, err
 	}

--- a/helper/sign_detached.go
+++ b/helper/sign_detached.go
@@ -3,7 +3,9 @@
 
 package helper
 
-import "github.com/ProtonMail/gopenpgp/v2/crypto"
+import (
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
 
 // EncryptSignAttachment encrypts an attachment using a detached signature, given a publicKey, a privateKey
 // and its passphrase, the filename, and the unencrypted file data.
@@ -16,7 +18,7 @@ func EncryptSignAttachment(
 	var packets *crypto.PGPSplitMessage
 	var signatureObj *crypto.PGPSignature
 
-	var binMessage = crypto.NewPlainMessageFromFile(plainData, filename, 0)
+	var binMessage = crypto.NewPlainMessageFromFile(plainData, filename, uint32(crypto.GetUnixTime()))
 
 	if publicKeyObj, err = crypto.NewKeyFromArmored(publicKey); err != nil {
 		return nil, nil, nil, err

--- a/helper/sign_detached.go
+++ b/helper/sign_detached.go
@@ -9,14 +9,14 @@ import "github.com/ProtonMail/gopenpgp/v2/crypto"
 // and its passphrase, the filename, and the unencrypted file data.
 // Returns keypacket, dataPacket and unarmored (!) signature separate.
 func EncryptSignAttachment(
-	publicKey, privateKey string, passphrase []byte, fileName string, plainData []byte,
+	publicKey, privateKey string, passphrase []byte, filename string, plainData []byte,
 ) (keyPacket, dataPacket, signature []byte, err error) {
 	var publicKeyObj, privateKeyObj, unlockedKeyObj *crypto.Key
 	var publicKeyRing, privateKeyRing *crypto.KeyRing
 	var packets *crypto.PGPSplitMessage
 	var signatureObj *crypto.PGPSignature
 
-	var binMessage = crypto.NewPlainMessage(plainData)
+	var binMessage = crypto.NewPlainMessageFromFile(plainData, filename, 0)
 
 	if publicKeyObj, err = crypto.NewKeyFromArmored(publicKey); err != nil {
 		return nil, nil, nil, err
@@ -45,7 +45,7 @@ func EncryptSignAttachment(
 		return nil, nil, nil, err
 	}
 
-	if packets, err = publicKeyRing.EncryptAttachment(binMessage, fileName); err != nil {
+	if packets, err = publicKeyRing.EncryptAttachment(binMessage, ""); err != nil {
 		return nil, nil, nil, err
 	}
 


### PR DESCRIPTION
Add the filename properties, and set them accordingly when decrypting messages