### PR TITLE
Improve error handling, fix linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,3 +29,4 @@ linters:
     - gofumpt           # Enforce a stricter format than gofmt
     - gci               # Enforce blank lines check
     - nlreturn          # Enforce blank lines for return statements
+    - exhaustivestruct  # Enforce structures to be fully filled on instantiation - terrible with openpgp configs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ NewPlainMessageFromFile(data []byte, filename string, modTime int) *PlainMessage
     now accept private keys as public keys and perform automatic casting if the keys are locked.
 - The `PlainMessage` struct now contains the fields `Filename` (string) and `Time` (uint32)
 - All the Decrypt* functions return the filename, type, and time specified in the encrypted message
+- Improved error wrapping and management
 
 ### Fixed
 - Public key armoring headers

--- a/armor/armor.go
+++ b/armor/armor.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/internal"
-
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp/armor"
 )
 
@@ -46,7 +46,7 @@ func ArmorWithTypeAndCustomHeaders(input []byte, armorType, version, comment str
 func Unarmor(input string) ([]byte, error) {
 	b, err := internal.Unarmor(input)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopengp: unable to unarmor")
 	}
 	return ioutil.ReadAll(b.Body)
 }
@@ -57,13 +57,13 @@ func armorWithTypeAndHeaders(input []byte, armorType string, headers map[string]
 	w, err := armor.Encode(&b, armorType, headers)
 
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "gopengp: unable to encode armoring")
 	}
 	if _, err = w.Write(input); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "gopengp: unable to write armored to buffer")
 	}
 	if err := w.Close(); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "gopengp: unable to close armor buffer")
 	}
 	return b.String(), nil
 }

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -186,7 +186,11 @@ func (key *Key) Serialize() ([]byte, error) {
 		err = key.entity.SerializePrivateWithoutSigning(&buffer, nil)
 	}
 
-	return buffer.Bytes(), errors.Wrap(err, "gopenpgp: error in serializing key")
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: error in serializing key")
+	}
+
+	return buffer.Bytes(), nil
 }
 
 // Armor returns the armored key as a string with default gopenpgp headers.

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -186,7 +186,7 @@ func (key *Key) Serialize() ([]byte, error) {
 		err = key.entity.SerializePrivateWithoutSigning(&buffer, nil)
 	}
 
-	return buffer.Bytes(), err
+	return buffer.Bytes(), errors.Wrap(err, "gopenpgp: error in serializing key")
 }
 
 // Armor returns the armored key as a string with default gopenpgp headers.
@@ -235,7 +235,7 @@ func (key *Key) GetArmoredPublicKeyWithCustomHeaders(comment, version string) (s
 func (key *Key) GetPublicKey() (b []byte, err error) {
 	var outBuf bytes.Buffer
 	if err = key.entity.Serialize(&outBuf); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in serializing public key")
 	}
 
 	return outBuf.Bytes(), nil
@@ -397,7 +397,7 @@ func (key *Key) readFrom(r io.Reader, armored bool) error {
 		entities, err = openpgp.ReadKeyRing(r)
 	}
 	if err != nil {
-		return err
+		return errors.Wrap(err, "gopenpgp: error in reading key ring")
 	}
 
 	if len(entities) > 1 {
@@ -456,7 +456,7 @@ func generateKey(
 
 	newEntity, err := openpgp.NewEntity(name, comments, email, cfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopengpp: error in encoding new entity")
 	}
 
 	if newEntity.PrivateKey == nil {

--- a/crypto/keyring.go
+++ b/crypto/keyring.go
@@ -82,8 +82,7 @@ func (keyRing *KeyRing) getSigningEntity() (*openpgp.Entity, error) {
 		}
 	}
 	if signEntity == nil {
-		err := errors.New("gopenpgp: cannot sign message, unable to unlock signer key")
-		return signEntity, err
+		return nil, errors.New("gopenpgp: cannot sign message, unable to unlock signer key")
 	}
 
 	return signEntity, nil

--- a/crypto/keyring_session.go
+++ b/crypto/keyring_session.go
@@ -2,7 +2,6 @@ package crypto
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -18,7 +17,7 @@ func (keyRing *KeyRing) DecryptSessionKey(keyPacket []byte) (*SessionKey, error)
 	var p packet.Packet
 	var err error
 	if p, err = packets.Next(); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in reading packets")
 	}
 
 	ek := p.(*packet.EncryptedKey)
@@ -35,7 +34,7 @@ func (keyRing *KeyRing) DecryptSessionKey(keyPacket []byte) (*SessionKey, error)
 	}
 
 	if decryptErr != nil {
-		return nil, decryptErr
+		return nil, errors.Wrap(decryptErr, "gopenpgp: error in decrypting")
 	}
 
 	if ek == nil {
@@ -68,8 +67,7 @@ func (keyRing *KeyRing) EncryptSessionKey(sk *SessionKey) ([]byte, error) {
 
 	for _, pub := range pubKeys {
 		if err := packet.SerializeEncryptedKey(outbuf, pub, cf, sk.Key, nil); err != nil {
-			err = fmt.Errorf("gopenpgp: cannot set key: %v", err)
-			return nil, err
+			return nil, errors.Wrap(err, "gopenpgp: cannot set key")
 		}
 	}
 	return outbuf.Bytes(), nil

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -24,7 +25,7 @@ func TestTextMessageEncryptionWithPassword(t *testing.T) {
 	for {
 		var p packet.Packet
 		var errEOF error
-		if p, errEOF = packets.Next(); errEOF == io.EOF {
+		if p, errEOF = packets.Next(); errors.Is(errEOF, io.EOF) {
 			break
 		}
 		sessionKey, ok := p.(*packet.SymmetricKeyEncrypted)
@@ -138,7 +139,7 @@ func TestIssue11(t *testing.T) {
 
 	issue11Keyring, err := NewKeyRing(issue11Key)
 	if err != nil {
-		t.Fatal("Expected no error while bulding private keyring, got:", err)
+		t.Fatal("Expected no error while building private keyring, got:", err)
 	}
 
 	senderKey, err := NewKeyFromArmored(readTestFile("issue11_publickey", false))
@@ -154,7 +155,7 @@ func TestIssue11(t *testing.T) {
 
 	pgpMessage, err := NewPGPMessageFromArmored(readTestFile("issue11_message", false))
 	if err != nil {
-		t.Fatal("Expected no error while unlocking private keyring, got:", err)
+		t.Fatal("Expected no error while reading ciphertext, got:", err)
 	}
 
 	plainMessage, err := issue11Keyring.Decrypt(pgpMessage, senderKeyring, 0)

--- a/crypto/mime.go
+++ b/crypto/mime.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	gomime "github.com/ProtonMail/go-mime"
-
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/packet"
 )
@@ -53,14 +53,14 @@ func parseMIME(
 ) (*gomime.BodyCollector, []string, []string, error) {
 	mm, err := mail.ReadMessage(strings.NewReader(mimeBody))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Wrap(err, "gopenpgp: error in reading message")
 	}
 	config := &packet.Config{DefaultCipher: packet.CipherAES256, Time: getTimeGenerator()}
 
 	h := textproto.MIMEHeader(mm.Header)
 	mmBodyData, err := ioutil.ReadAll(mm.Body)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Wrap(err, "gopenpgp: error in reading message body data")
 	}
 
 	printAccepter := gomime.NewMIMEPrinter()

--- a/crypto/password.go
+++ b/crypto/password.go
@@ -119,16 +119,16 @@ func passwordEncrypt(message *PlainMessage, password []byte) ([]byte, error) {
 
 	encryptWriter, err := openpgp.SymmetricallyEncrypt(&outBuf, password, hints, config)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in encrypting message symmetrically")
 	}
 	_, err = encryptWriter.Write(message.GetBinary())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in writing data to message")
 	}
 
 	err = encryptWriter.Close()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in closing writer")
 	}
 
 	return outBuf.Bytes(), nil
@@ -151,13 +151,13 @@ func passwordDecrypt(encryptedIO io.Reader, password []byte) (*PlainMessage, err
 	var emptyKeyRing openpgp.EntityList
 	md, err := openpgp.ReadMessage(encryptedIO, emptyKeyRing, prompt, config)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in reading password protected message")
 	}
 
 	messageBuf := bytes.NewBuffer(nil)
 	_, err = io.Copy(messageBuf, md.UnverifiedBody)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in reading password protected message body")
 	}
 
 	return &PlainMessage{

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -50,7 +50,7 @@ func RandomToken(size int) ([]byte, error) {
 	config := &packet.Config{DefaultCipher: packet.CipherAES256}
 	symKey := make([]byte, size)
 	if _, err := io.ReadFull(config.Random(), symKey); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in generating random token")
 	}
 	return symKey, nil
 }
@@ -152,12 +152,12 @@ func (sk *SessionKey) Encrypt(message *PlainMessage) ([]byte, error) {
 
 	_, err = encryptWriter.Write(message.GetBinary())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in writing message")
 	}
 
 	err = encryptWriter.Close()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in closing message")
 	}
 
 	return encBuf.Bytes(), nil
@@ -213,7 +213,7 @@ func (sk *SessionKey) Decrypt(dataPacket []byte) (*PlainMessage, error) {
 	messageBuf := new(bytes.Buffer)
 	_, err = messageBuf.ReadFrom(md.UnverifiedBody)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: error in reading message body")
 	}
 
 	return &PlainMessage{
@@ -221,7 +221,7 @@ func (sk *SessionKey) Decrypt(dataPacket []byte) (*PlainMessage, error) {
 		TextType: !md.LiteralData.IsBinary,
 		Filename: md.LiteralData.FileName,
 		Time:     md.LiteralData.Time,
-	}, err
+	}, nil
 }
 
 func (sk *SessionKey) checkSize() error {

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"errors"
 	"regexp"
 	"testing"
 
@@ -44,7 +45,8 @@ func TestVerifyTextDetachedSigWrong(t *testing.T) {
 
 	assert.EqualError(t, verificationError, "Signature Verification Error: Invalid signature")
 
-	err, _ := verificationError.(SignatureVerificationError)
+	err := &SignatureVerificationError{}
+	_ = errors.As(verificationError, err)
 	assert.Exactly(t, constants.SIGNATURE_FAILED, err.Status)
 }
 

--- a/helper/cleartext.go
+++ b/helper/cleartext.go
@@ -54,7 +54,7 @@ func SignCleartextMessage(keyRing *crypto.KeyRing, text string) (string, error) 
 
 	signature, err := keyRing.SignDetached(message)
 	if err != nil {
-		return "", errors.Wrap(err, "gopenpgp: error in signing message")
+		return "", errors.Wrap(err, "gopenpgp: error in signing cleartext message")
 	}
 
 	return crypto.NewClearTextMessage(message.GetBinary(), signature.GetBinary()).GetArmored()
@@ -66,14 +66,14 @@ func SignCleartextMessage(keyRing *crypto.KeyRing, text string) (string, error) 
 func VerifyCleartextMessage(keyRing *crypto.KeyRing, armored string, verifyTime int64) (string, error) {
 	clearTextMessage, err := crypto.NewClearTextMessageFromArmored(armored)
 	if err != nil {
-		return "", errors.Wrap(err, "gopengpp: unable to unarmor message")
+		return "", errors.Wrap(err, "gopengpp: unable to unarmor cleartext message")
 	}
 
 	message := crypto.NewPlainMessageFromString(clearTextMessage.GetString())
 	signature := crypto.NewPGPSignature(clearTextMessage.GetBinarySignature())
 	err = keyRing.VerifyDetached(message, signature, verifyTime)
 	if err != nil {
-		return "", errors.Wrap(err, "gopengpp: unable to verify message")
+		return "", errors.Wrap(err, "gopengpp: unable to verify cleartext message")
 	}
 
 	return message.GetString(), nil

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -18,7 +18,7 @@ func TestAESEncryption(t *testing.T) {
 	}
 
 	_, err = DecryptMessageWithPassword([]byte("Wrong passphrase"), ciphertext)
-	assert.EqualError(t, err, "gopenpgp: unable to decrypt message with password: " +
+	assert.EqualError(t, err, "gopenpgp: unable to decrypt message with password: "+
 		"gopenpgp: error in reading password protected message: gopenpgp: wrong password in symmetric decryption")
 
 	decrypted, err := DecryptMessageWithPassword(passphrase, ciphertext)

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -18,7 +18,8 @@ func TestAESEncryption(t *testing.T) {
 	}
 
 	_, err = DecryptMessageWithPassword([]byte("Wrong passphrase"), ciphertext)
-	assert.EqualError(t, err, "gopenpgp: wrong password in symmetric decryption")
+	assert.EqualError(t, err, "gopenpgp: unable to decrypt message with password: " +
+		"gopenpgp: error in reading password protected message: gopenpgp: wrong password in symmetric decryption")
 
 	decrypted, err := DecryptMessageWithPassword(passphrase, ciphertext)
 	if err != nil {
@@ -71,7 +72,7 @@ func TestArmoredTextMessageEncryptionVerification(t *testing.T) {
 		testMailboxPassword, // Password defined in base_test
 		armored,
 	)
-	assert.EqualError(t, err, "Signature Verification Error: No matching signature")
+	assert.EqualError(t, err, "gopenpgp: unable to decrypt message: Signature Verification Error: No matching signature")
 
 	decrypted, err := DecryptVerifyMessageArmored(
 		readTestFile("keyring_privateKey", false),

--- a/helper/key.go
+++ b/helper/key.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
+	"github.com/pkg/errors"
 )
 
 // UpdatePrivateKeyPassphrase decrypts the given armored privateKey with oldPassphrase,
@@ -12,21 +13,26 @@ func UpdatePrivateKeyPassphrase(
 ) (string, error) {
 	key, err := crypto.NewKeyFromArmored(privateKey)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "gopenpgp: unable to parse key")
 	}
 
 	unlocked, err := key.Unlock(oldPassphrase)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "gopenpgp: unable to unlock old key")
 	}
 	defer unlocked.ClearPrivateParams()
 
 	locked, err := unlocked.Lock(newPassphrase)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "gopenpgp: unable to lock new key")
 	}
 
-	return locked.Armor()
+	armored, err := locked.Armor()
+	if err != nil {
+		return "", errors.Wrap(err, "gopenpgp: unable to armor new key")
+	}
+
+	return armored, nil
 }
 
 // GenerateKey generates a key of the given keyType ("rsa" or "x25519"), encrypts it, and returns an armored string.
@@ -35,13 +41,13 @@ func UpdatePrivateKeyPassphrase(
 func GenerateKey(name, email string, passphrase []byte, keyType string, bits int) (string, error) {
 	key, err := crypto.GenerateKey(name, email, keyType, bits)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "gopenpgp: unable to generate new key")
 	}
 	defer key.ClearPrivateParams()
 
 	locked, err := key.Lock(passphrase)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "gopenpgp: unable to lock new key")
 	}
 
 	return locked.Armor()
@@ -50,7 +56,7 @@ func GenerateKey(name, email string, passphrase []byte, keyType string, bits int
 func GetSHA256Fingerprints(publicKey string) ([]string, error) {
 	key, err := crypto.NewKeyFromArmored(publicKey)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: unable to parse key")
 	}
 
 	return key.GetSHA256Fingerprints(), nil

--- a/helper/mobile.go
+++ b/helper/mobile.go
@@ -2,8 +2,10 @@ package helper
 
 import (
 	"encoding/json"
+	goerrors "errors"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
+	"github.com/pkg/errors"
 )
 
 type ExplicitVerifyMessage struct {
@@ -24,14 +26,15 @@ func DecryptExplicitVerify(
 	message, err := privateKeyRing.Decrypt(pgpMessage, publicKeyRing, verifyTime)
 
 	if err != nil {
-		castedErr, isType := err.(crypto.SignatureVerificationError)
+		castedErr := &crypto.SignatureVerificationError{}
+		isType := goerrors.As(err, castedErr)
 		if !isType {
-			return nil, err
+			return nil, errors.Wrap(err, "gopenpgp: unable to decrypt message")
 		}
 
 		explicitVerify = &ExplicitVerifyMessage{
 			Message:                    message,
-			SignatureVerificationError: &castedErr,
+			SignatureVerificationError: castedErr,
 		}
 	} else {
 		explicitVerify = &ExplicitVerifyMessage{
@@ -51,7 +54,7 @@ func DecryptAttachment(keyPacket []byte, dataPacket []byte, keyRing *crypto.KeyR
 
 	decrypted, err := keyRing.DecryptAttachment(splitMessage)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: unable to decrypt attachment")
 	}
 	return decrypted, nil
 }
@@ -64,7 +67,7 @@ func EncryptAttachment(plainData []byte, filename string, keyRing *crypto.KeyRin
 	plainMessage := crypto.NewPlainMessageFromFile(plainData, filename, uint32(crypto.GetUnixTime()))
 	decrypted, err := keyRing.EncryptAttachment(plainMessage, "")
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: unable to encrypt attachment")
 	}
 	return decrypted, nil
 }
@@ -74,7 +77,7 @@ func EncryptAttachment(plainData []byte, filename string, keyRing *crypto.KeyRin
 func GetJsonSHA256Fingerprints(publicKey string) ([]byte, error) {
 	key, err := crypto.NewKeyFromArmored(publicKey)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: unable to parse key")
 	}
 
 	return json.Marshal(key.GetSHA256Fingerprints())
@@ -94,5 +97,9 @@ func EncryptSignArmoredDetachedMobile(
 	if err != nil {
 		return nil, err
 	}
-	return &EncryptSignArmoredDetachedMobileResult{ciphertext, encryptedSignature}, nil
+
+	return &EncryptSignArmoredDetachedMobileResult{
+		Ciphertext:         ciphertext,
+		EncryptedSignature: encryptedSignature,
+	}, nil
 }

--- a/helper/sign_detached.go
+++ b/helper/sign_detached.go
@@ -5,6 +5,7 @@ package helper
 
 import (
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
+	"github.com/pkg/errors"
 )
 
 // EncryptSignAttachment encrypts an attachment using a detached signature, given a publicKey, a privateKey
@@ -13,46 +14,36 @@ import (
 func EncryptSignAttachment(
 	publicKey, privateKey string, passphrase []byte, filename string, plainData []byte,
 ) (keyPacket, dataPacket, signature []byte, err error) {
-	var publicKeyObj, privateKeyObj, unlockedKeyObj *crypto.Key
+	var privateKeyObj, unlockedKeyObj *crypto.Key
 	var publicKeyRing, privateKeyRing *crypto.KeyRing
 	var packets *crypto.PGPSplitMessage
 	var signatureObj *crypto.PGPSignature
 
 	var binMessage = crypto.NewPlainMessageFromFile(plainData, filename, uint32(crypto.GetUnixTime()))
 
-	if publicKeyObj, err = crypto.NewKeyFromArmored(publicKey); err != nil {
-		return nil, nil, nil, err
-	}
-	if publicKeyObj.IsPrivate() {
-		publicKeyObj, err = publicKeyObj.ToPublic()
-		if err != nil {
-			return nil, nil, nil, err
-		}
-	}
-
-	if publicKeyRing, err = crypto.NewKeyRing(publicKeyObj); err != nil {
+	if publicKeyRing, err = createPublicKeyRing(publicKey); err != nil {
 		return nil, nil, nil, err
 	}
 
 	if privateKeyObj, err = crypto.NewKeyFromArmored(privateKey); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Wrap(err, "gopenpgp: unable to parse private key")
 	}
 
 	if unlockedKeyObj, err = privateKeyObj.Unlock(passphrase); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Wrap(err, "gopenpgp: unable to unlock key")
 	}
 	defer unlockedKeyObj.ClearPrivateParams()
 
 	if privateKeyRing, err = crypto.NewKeyRing(unlockedKeyObj); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Wrap(err, "gopenpgp: unable to create private keyring")
 	}
 
 	if packets, err = publicKeyRing.EncryptAttachment(binMessage, ""); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Wrap(err, "gopenpgp: unable to encrypt attachment")
 	}
 
 	if signatureObj, err = privateKeyRing.SignDetached(binMessage); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Wrap(err, "gopenpgp: unable to sign attachment")
 	}
 
 	return packets.GetBinaryKeyPacket(), packets.GetBinaryDataPacket(), signatureObj.GetBinary(), nil

--- a/internal/armor.go
+++ b/internal/armor.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"strings"
 
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp/armor"
 )
 
@@ -11,7 +12,7 @@ func Unarmor(input string) (*armor.Block, error) {
 	io := strings.NewReader(input)
 	b, err := armor.Decode(io)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gopenpgp: unable to armor")
 	}
 	return b, nil
 }


### PR DESCRIPTION
- Wrap errors to allow for easier debugging
- Use `errors.Is` and `errors.As` to check/cast errors