### PR TITLE
Duplicate the helpers for plain and encrypted signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,14 +46,42 @@ DecryptBinaryMessageArmored(privateKey string, passphrase []byte, ciphertext str
 (key *Key) ToPublic() (publicKey *Key, err error) 
 ```
 
-- Helpers to handle encryption (both with armored and unarmored cipher) + encrypted detached signatures in one call.
+- Helpers to handle encryption (both with armored and unarmored cipher) + **plain** detached armored signatures in one call.
 ```go
 EncryptSignArmoredDetached(
 	publicKey, privateKey string,
 	passphrase, plainData []byte,
-) (ciphertextArmored, encryptedSignatureArmored string, err error)
+) (ciphertextArmored, signatureArmored string, err error)
 
 DecryptVerifyArmoredDetached(
+	publicKey, privateKey string,
+	passphrase []byte,
+	ciphertextArmored string,
+	signatureArmored string,
+) (plainData []byte, err error)
+```
+```go
+EncryptSignBinaryDetached(
+	publicKey, privateKey string,
+	passphrase, plainData []byte,
+) (encryptedData []byte, signatureArmored string, err error)
+
+DecryptVerifyBinaryDetached(
+	publicKey, privateKey string,
+	passphrase []byte,
+	encryptedData []byte,
+	signatureArmored string,
+) (plainData []byte, err error)
+```
+
+- Helpers to handle encryption (both with armored and unarmored cipher) + **encrypted** detached armored signatures in one call.
+```go
+EncryptSignArmoredDetachedEncrypted(
+	publicKey, privateKey string,
+	passphrase, plainData []byte,
+) (ciphertextArmored, encryptedSignatureArmored string, err error)
+
+DecryptVerifyArmoredDetachedEncrypted(
 	publicKey, privateKey string,
 	passphrase []byte,
 	ciphertextArmored string,
@@ -61,19 +89,20 @@ DecryptVerifyArmoredDetached(
 ) (plainData []byte, err error)
 ```
 ```go
-EncryptSignBinaryDetached(
+EncryptSignBinaryDetachedEncrypted(
 	publicKey, privateKey string,
 	passphrase, plainData []byte,
 ) (encryptedData []byte, encryptedSignatureArmored string, err error)
 
-DecryptVerifyBinaryDetached(
+DecryptVerifyBinaryDetachedEncrypted(
 	publicKey, privateKey string,
 	passphrase []byte,
 	encryptedData []byte,
 	encryptedSignatureArmored string,
 ) (plainData []byte, err error)
 ```
-- Wrappers for `EncryptSignArmoredDetached` and `EncryptSignBinaryDetached` helpers, to be usable with gomobile (that doesn't support multiple retun values). These wrappers return custom structs instead.
+
+- Wrappers for `EncryptSignArmoredDetached`, `EncryptSignBinaryDetached`, `EncryptSignArmoredDetachedEncrypted` and `EncryptSignBinaryDetachedEncrypted` helpers, to be usable with gomobile (that doesn't support multiple retun values). These wrappers return custom structs instead.
 ```go
 type EncryptSignArmoredDetachedMobileResult struct {
 	CiphertextArmored, EncryptedSignatureArmored string
@@ -94,6 +123,27 @@ EncryptSignBinaryDetachedMobile(
 	publicKey, privateKey string,
 	passphrase, plainData []byte,
 ) (wrappedTuple *EncryptSignBinaryDetachedMobileResult, err error) 
+```
+```go
+type EncryptSignArmoredDetachedEncryptedMobileResult struct {
+	CiphertextArmored, EncryptedSignatureArmored string
+}
+
+EncryptSignArmoredDetachedEncryptedMobile(
+	publicKey, privateKey string,
+	passphrase, plainData []byte,
+) (wrappedTuple *EncryptSignArmoredDetachedEncryptedMobileResult, err error) 
+```
+```go
+type EncryptSignBinaryDetachedEncryptedMobileResult struct {
+	EncryptedData             []byte
+	EncryptedSignatureArmored string
+}
+
+func EncryptSignBinaryDetachedEncryptedMobile(
+	publicKey, privateKey string,
+	passphrase, plainData []byte,
+) (wrappedTuple *EncryptSignBinaryDetachedEncryptedMobileResult, err error)
 ```
 
 - helpers to encrypt/decrypt session keys with armored keys:

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -353,3 +353,125 @@ func TestEncryptSignBinaryDetached(t *testing.T) {
 		t.Fatal("Expected an error while decrypting and verifying with a wrong signature")
 	}
 }
+
+func TestEncryptSignBinaryDetachedEncrypted(t *testing.T) {
+	plainData := []byte("Secret message")
+	privateKeyString := readTestFile("keyring_privateKey", false)
+	privateKey, err := crypto.NewKeyFromArmored(privateKeyString)
+	if err != nil {
+		t.Fatal("Error reading the test private key: ", err)
+	}
+	publicKeyString, err := privateKey.GetArmoredPublicKey()
+	if err != nil {
+		t.Fatal("Error reading the test public key: ", err)
+	}
+	encryptedData, armoredSignature, err := EncryptSignBinaryDetachedEncrypted(
+		publicKeyString,
+		privateKeyString,
+		testMailboxPassword, // Password defined in base_test
+		plainData,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while encrypting and signing, got:", err)
+	}
+
+	decrypted, err := DecryptVerifyBinaryDetachedEncrypted(
+		publicKeyString,
+		privateKeyString,
+		testMailboxPassword,
+		encryptedData,
+		armoredSignature,
+	)
+
+	if err != nil {
+		t.Fatal("Expected no error while decrypting and verifying, got:", err)
+	}
+
+	if !bytes.Equal(decrypted, plainData) {
+		t.Error("Decrypted is not equal to the plaintext")
+	}
+
+	_, modifiedSignature, err := EncryptSignBinaryDetachedEncrypted(
+		publicKeyString,
+		privateKeyString,
+		testMailboxPassword, // Password defined in base_test
+		[]byte("Different message"),
+	)
+
+	if err != nil {
+		t.Fatal("Expected no error while encrypting and signing, got:", err)
+	}
+
+	_, err = DecryptVerifyBinaryDetached(
+		publicKeyString,
+		privateKeyString,
+		testMailboxPassword,
+		encryptedData,
+		modifiedSignature,
+	)
+
+	if err == nil {
+		t.Fatal("Expected an error while decrypting and verifying with a wrong signature")
+	}
+}
+
+func TestEncryptSignArmoredDetachedEncrypted(t *testing.T) {
+	plainData := []byte("Secret message")
+	privateKeyString := readTestFile("keyring_privateKey", false)
+	privateKey, err := crypto.NewKeyFromArmored(privateKeyString)
+	if err != nil {
+		t.Fatal("Error reading the test private key: ", err)
+	}
+	publicKeyString, err := privateKey.GetArmoredPublicKey()
+	if err != nil {
+		t.Fatal("Error reading the test public key: ", err)
+	}
+	armoredCiphertext, armoredSignature, err := EncryptSignArmoredDetachedEncrypted(
+		publicKeyString,
+		privateKeyString,
+		testMailboxPassword, // Password defined in base_test
+		plainData,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while encrypting and signing, got:", err)
+	}
+
+	decrypted, err := DecryptVerifyArmoredDetachedEncrypted(
+		publicKeyString,
+		privateKeyString,
+		testMailboxPassword,
+		armoredCiphertext,
+		armoredSignature,
+	)
+
+	if err != nil {
+		t.Fatal("Expected no error while decrypting and verifying, got:", err)
+	}
+
+	if !bytes.Equal(decrypted, plainData) {
+		t.Error("Decrypted is not equal to the plaintext")
+	}
+
+	_, modifiedSignature, err := EncryptSignArmoredDetachedEncrypted(
+		publicKeyString,
+		privateKeyString,
+		testMailboxPassword, // Password defined in base_test
+		[]byte("Different message"),
+	)
+
+	if err != nil {
+		t.Fatal("Expected no error while encrypting and signing, got:", err)
+	}
+
+	_, err = DecryptVerifyArmoredDetachedEncrypted(
+		publicKeyString,
+		privateKeyString,
+		testMailboxPassword,
+		armoredCiphertext,
+		modifiedSignature,
+	)
+
+	if err == nil {
+		t.Fatal("Expected an error while decrypting and verifying with a wrong signature")
+	}
+}

--- a/helper/mobile.go
+++ b/helper/mobile.go
@@ -83,8 +83,9 @@ func GetJsonSHA256Fingerprints(publicKey string) ([]byte, error) {
 	return json.Marshal(key.GetSHA256Fingerprints())
 }
 
+// EncryptSignArmoredDetachedMobileResult is a wrapper for gomobile
 type EncryptSignArmoredDetachedMobileResult struct {
-	CiphertextArmored, EncryptedSignatureArmored string
+	CiphertextArmored, SignatureArmored string
 }
 
 // EncryptSignArmoredDetachedMobile wraps the encryptSignArmoredDetached method
@@ -93,20 +94,21 @@ func EncryptSignArmoredDetachedMobile(
 	publicKey, privateKey string,
 	passphrase, plainData []byte,
 ) (wrappedTuple *EncryptSignArmoredDetachedMobileResult, err error) {
-	ciphertext, encryptedSignature, err := encryptSignArmoredDetached(publicKey, privateKey, passphrase, plainData)
+	ciphertext, signature, err := encryptSignArmoredDetached(publicKey, privateKey, passphrase, plainData)
 	if err != nil {
 		return nil, err
 	}
 
 	return &EncryptSignArmoredDetachedMobileResult{
-		CiphertextArmored:         ciphertext,
-		EncryptedSignatureArmored: encryptedSignature,
+		CiphertextArmored: ciphertext,
+		SignatureArmored:  signature,
 	}, nil
 }
 
+// EncryptSignBinaryDetachedMobileResult is a wrapper for gomobile
 type EncryptSignBinaryDetachedMobileResult struct {
-	EncryptedData             []byte
-	EncryptedSignatureArmored string
+	EncryptedData    []byte
+	SignatureArmored string
 }
 
 // EncryptSignBinaryDetachedMobile wraps the encryptSignBinaryDetached method
@@ -115,11 +117,56 @@ func EncryptSignBinaryDetachedMobile(
 	publicKey, privateKey string,
 	passphrase, plainData []byte,
 ) (wrappedTuple *EncryptSignBinaryDetachedMobileResult, err error) {
-	ciphertext, encryptedSignature, err := encryptSignBinaryDetached(publicKey, privateKey, passphrase, plainData)
+	ciphertext, signature, err := encryptSignBinaryDetached(publicKey, privateKey, passphrase, plainData)
 	if err != nil {
 		return nil, err
 	}
 	return &EncryptSignBinaryDetachedMobileResult{
+		EncryptedData:    ciphertext,
+		SignatureArmored: signature,
+	}, nil
+}
+
+// EncryptSignArmoredDetachedEncryptedMobileResult is a wrapper for gomobile
+type EncryptSignArmoredDetachedEncryptedMobileResult struct {
+	CiphertextArmored, EncryptedSignatureArmored string
+}
+
+// EncryptSignArmoredDetachedEncryptedMobile wraps
+// the encryptSignArmoredDetachedEncrypted method
+// to have only one return argument for mobile.
+func EncryptSignArmoredDetachedEncryptedMobile(
+	publicKey, privateKey string,
+	passphrase, plainData []byte,
+) (wrappedTuple *EncryptSignArmoredDetachedEncryptedMobileResult, err error) {
+	ciphertext, encryptedSignature, err := encryptSignArmoredDetachedEncrypted(publicKey, privateKey, passphrase, plainData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EncryptSignArmoredDetachedEncryptedMobileResult{
+		CiphertextArmored:         ciphertext,
+		EncryptedSignatureArmored: encryptedSignature,
+	}, nil
+}
+
+// EncryptSignBinaryDetachedEncryptedMobileResult is a wrapper for gomobile
+type EncryptSignBinaryDetachedEncryptedMobileResult struct {
+	EncryptedData             []byte
+	EncryptedSignatureArmored string
+}
+
+// EncryptSignBinaryDetachedEncryptedMobile wraps the encryptSignBinaryDetached method
+// to have only one return argument for mobile.
+func EncryptSignBinaryDetachedEncryptedMobile(
+	publicKey, privateKey string,
+	passphrase, plainData []byte,
+) (wrappedTuple *EncryptSignBinaryDetachedEncryptedMobileResult, err error) {
+	ciphertext, encryptedSignature, err := encryptSignBinaryDetachedEncrypted(publicKey, privateKey, passphrase, plainData)
+	if err != nil {
+		return nil, err
+	}
+	return &EncryptSignBinaryDetachedEncryptedMobileResult{
 		EncryptedData:             ciphertext,
 		EncryptedSignatureArmored: encryptedSignature,
 	}, nil

--- a/helper/mobile.go
+++ b/helper/mobile.go
@@ -83,7 +83,7 @@ func GetJsonSHA256Fingerprints(publicKey string) ([]byte, error) {
 	return json.Marshal(key.GetSHA256Fingerprints())
 }
 
-// EncryptSignArmoredDetachedMobileResult is a wrapper for gomobile
+// EncryptSignArmoredDetachedMobileResult is a wrapper for gomobile.
 type EncryptSignArmoredDetachedMobileResult struct {
 	CiphertextArmored, SignatureArmored string
 }
@@ -105,7 +105,7 @@ func EncryptSignArmoredDetachedMobile(
 	}, nil
 }
 
-// EncryptSignBinaryDetachedMobileResult is a wrapper for gomobile
+// EncryptSignBinaryDetachedMobileResult is a wrapper for gomobile.
 type EncryptSignBinaryDetachedMobileResult struct {
 	EncryptedData    []byte
 	SignatureArmored string
@@ -127,7 +127,7 @@ func EncryptSignBinaryDetachedMobile(
 	}, nil
 }
 
-// EncryptSignArmoredDetachedEncryptedMobileResult is a wrapper for gomobile
+// EncryptSignArmoredDetachedEncryptedMobileResult is a wrapper for gomobile.
 type EncryptSignArmoredDetachedEncryptedMobileResult struct {
 	CiphertextArmored, EncryptedSignatureArmored string
 }
@@ -150,7 +150,7 @@ func EncryptSignArmoredDetachedEncryptedMobile(
 	}, nil
 }
 
-// EncryptSignBinaryDetachedEncryptedMobileResult is a wrapper for gomobile
+// EncryptSignBinaryDetachedEncryptedMobileResult is a wrapper for gomobile.
 type EncryptSignBinaryDetachedEncryptedMobileResult struct {
 	EncryptedData             []byte
 	EncryptedSignatureArmored string

--- a/helper/sign_detached.go
+++ b/helper/sign_detached.go
@@ -51,20 +51,40 @@ func EncryptSignAttachment(
 
 // EncryptSignArmoredDetached takes a public key for encryption,
 // a private key and its passphrase for signature, and the plaintext data
-// Returns an armored ciphertext and a detached armored signature.
+// Returns an armored ciphertext and a detached armored plain signature.
 func EncryptSignArmoredDetached(
 	publicKey, privateKey string,
 	passphrase, plainData []byte,
-) (ciphertextArmored, encryptedSignatureArmored string, err error) {
+) (ciphertextArmored, signatureArmored string, err error) {
 	return encryptSignArmoredDetached(publicKey, privateKey, passphrase, plainData)
 }
 
 // EncryptSignBinaryDetached takes a public key for encryption,
 // a private key and its passphrase for signature, and the plaintext data
-// Returns encrypted binary data and a detached armored encrypted signature.
+// Returns encrypted binary data and a detached armored plain signature.
 func EncryptSignBinaryDetached(
 	publicKey, privateKey string,
 	passphrase, plainData []byte,
-) (encryptedData []byte, encryptedSignatureArmored string, err error) {
+) (encryptedData []byte, signatureArmored string, err error) {
 	return encryptSignBinaryDetached(publicKey, privateKey, passphrase, plainData)
+}
+
+// EncryptSignArmoredDetachedEncrypted takes a public key for encryption,
+// a private key and its passphrase for signature, and the plaintext data
+// Returns an armored ciphertext and a detached armored encrypted signature.
+func EncryptSignArmoredDetachedEncrypted(
+	publicKey, privateKey string,
+	passphrase, plainData []byte,
+) (ciphertextArmored, encryptedSignatureArmored string, err error) {
+	return encryptSignArmoredDetachedEncrypted(publicKey, privateKey, passphrase, plainData)
+}
+
+// EncryptSignBinaryDetachedEncrypted takes a public key for encryption,
+// a private key and its passphrase for signature, and the plaintext data
+// Returns encrypted binary data and a detached armored encrypted signature.
+func EncryptSignBinaryDetachedEncrypted(
+	publicKey, privateKey string,
+	passphrase, plainData []byte,
+) (encryptedData []byte, encryptedSignatureArmored string, err error) {
+	return encryptSignBinaryDetachedEncrypted(publicKey, privateKey, passphrase, plainData)
 }


### PR DESCRIPTION
There was confusion were we changed the behavior of the helpers EncryptSignArmoredDetached and DetachedVerifyArmoredDetached to use encrypted signatures instead of plaintext signatures.
In this PR, we revert the behavior of these to use plain signatures, and we add new helpers to handle encrypted signatures.