### PR TITLE
Update x/crypto fork to github.com/ProtonMail/go-crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ require (
     ...
     github.com/ProtonMail/gopenpgp/v2 v2.0.1
 )
-
-replace golang.org/x/crypto => github.com/ProtonMail/crypto master
 ```
 
 It can then be installed by running:

--- a/armor/armor.go
+++ b/armor/armor.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/internal"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp/armor"
 )
 
 // ArmorKey armors input as a public key.

--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 // AttachmentProcessor keeps track of the progress of encrypting an attachment

--- a/crypto/base_test.go
+++ b/crypto/base_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/crypto/ed25519"
-	"golang.org/x/crypto/openpgp/ecdh"
-	"golang.org/x/crypto/rsa"
+	"github.com/ProtonMail/go-crypto/ed25519"
+	"github.com/ProtonMail/go-crypto/openpgp/ecdh"
+	"github.com/ProtonMail/go-crypto/rsa"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -15,8 +15,8 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/pkg/errors"
 
-	openpgp "golang.org/x/crypto/openpgp"
-	packet "golang.org/x/crypto/openpgp/packet"
+	openpgp "github.com/ProtonMail/go-crypto/openpgp"
+	packet "github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 // Key contains a single private or public key.

--- a/crypto/key_clear.go
+++ b/crypto/key_clear.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"math/big"
 
-	"golang.org/x/crypto/ed25519"
-	"golang.org/x/crypto/openpgp/ecdh"
-	"golang.org/x/crypto/openpgp/elgamal"
-	"golang.org/x/crypto/rsa"
+	"github.com/ProtonMail/go-crypto/ed25519"
+	"github.com/ProtonMail/go-crypto/openpgp/ecdh"
+	"github.com/ProtonMail/go-crypto/openpgp/elgamal"
+	"github.com/ProtonMail/go-crypto/rsa"
 )
 
 func (sk *SessionKey) Clear() (ok bool) {

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/armor"
-	"golang.org/x/crypto/rsa"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/rsa"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/crypto/keyring.go
+++ b/crypto/keyring.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 // KeyRing contains multiple private and public keys.

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 // Encrypt encrypts a PlainMessage, outputs a PGPMessage.

--- a/crypto/keyring_session.go
+++ b/crypto/keyring_session.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 // DecryptSessionKey returns the decrypted session key from one or multiple binary encrypted session key packets.

--- a/crypto/keyring_test.go
+++ b/crypto/keyring_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"golang.org/x/crypto/ed25519"
-	"golang.org/x/crypto/openpgp/ecdh"
-	"golang.org/x/crypto/rsa"
+	"github.com/ProtonMail/go-crypto/ed25519"
+	"github.com/ProtonMail/go-crypto/openpgp/ecdh"
+	"github.com/ProtonMail/go-crypto/rsa"
 )
 
 var testSymmetricKey []byte

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/ProtonMail/gopenpgp/v2/armor"
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/internal"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp/clearsign"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 // ---- MODELS -----

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 func TestTextMessageEncryptionWithPassword(t *testing.T) {

--- a/crypto/mime.go
+++ b/crypto/mime.go
@@ -7,10 +7,10 @@ import (
 	"net/textproto"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	gomime "github.com/ProtonMail/go-mime"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 // MIMECallbacks defines callback methods to process a MIME message.

--- a/crypto/password.go
+++ b/crypto/password.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 // EncryptMessageWithPassword encrypts a PlainMessage to PGPMessage with a

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/pkg/errors"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 // SessionKey stores a decrypted session key.

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -9,9 +9,9 @@ import (
 	"math"
 	"time"
 
-	"golang.org/x/crypto/openpgp"
-	pgpErrors "golang.org/x/crypto/openpgp/errors"
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	pgpErrors "github.com/ProtonMail/go-crypto/openpgp/errors"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/internal"

--- a/crypto/signature_collector.go
+++ b/crypto/signature_collector.go
@@ -7,10 +7,10 @@ import (
 	"mime"
 	"net/textproto"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	gomime "github.com/ProtonMail/go-mime"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 // SignatureCollector structure.

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,11 @@ module github.com/ProtonMail/gopenpgp/v2
 go 1.15
 
 require (
+	github.com/ProtonMail/go-crypto v0.0.0-20201208171014-cdb7591792e2
 	github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/mobile v0.0.0-20200801112145-973feb4309de
 )
-
-replace golang.org/x/crypto => github.com/ProtonMail/crypto v0.0.0-20201112115411-41db4ea0dd1c
 
 replace golang.org/x/mobile => github.com/marinthiercelin/mobile v0.0.0-20201127122539-61ba718dc1d1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ProtonMail/crypto v0.0.0-20201112115411-41db4ea0dd1c h1:iaVbEOnskSGgcH7XQWHG6VPirHDRoYe+Idd0/dl4m8A=
-github.com/ProtonMail/crypto v0.0.0-20201112115411-41db4ea0dd1c/go.mod h1:Pxr7w4gA2ikI4sWyYwEffm+oew1WAJHzG1SiDpQMkrI=
+github.com/ProtonMail/go-crypto v0.0.0-20201208171014-cdb7591792e2 h1:pQkjJELHayW59jp7r4G5Dlmnicr5McejDfwsjcwI1SU=
+github.com/ProtonMail/go-crypto v0.0.0-20201208171014-cdb7591792e2/go.mod h1:HTM9X7e9oLwn7RiqLG0UVwVRJenLs3wN+tQ0NPAfwMQ=
 github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a h1:W6RrgN/sTxg1msqzFFb+G80MFmpjMw61IU+slm+wln4=
 github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a/go.mod h1:NYt+V3/4rEeDuaev/zw1zCq8uqVEuPHzDPo3OZrlGJ4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -8,6 +8,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/marinthiercelin/mobile v0.0.0-20201127122539-61ba718dc1d1/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -20,6 +21,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/zhj4478/mobile v0.0.0-20201014085805-7a2d68bf792f/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -34,6 +38,9 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/internal/armor.go
+++ b/internal/armor.go
@@ -3,8 +3,8 @@ package internal
 import (
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp/armor"
 )
 
 // Unarmor unarmors an armored string.

--- a/subtle/subtle.go
+++ b/subtle/subtle.go
@@ -6,7 +6,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 
-	"golang.org/x/crypto/scrypt"
+	"github.com/ProtonMail/go-crypto/scrypt"
 )
 
 // EncryptWithoutIntegrity encrypts data with AES-CTR. Note: this encryption


### PR DESCRIPTION
This way, users of gopenpgp don't need to add a `replace` to their go.mod anymore.