### PR TITLE
Draft: Decryption with io.Reader

### DIFF
--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/openpgp/armor"
 )
 
 // Encrypt encrypts a PlainMessage, outputs a PGPMessage.
@@ -77,18 +78,18 @@ func (keyRing *KeyRing) DecryptUnarmoredStreamUnverified(
 	return messageDetails.UnverifiedBody, nil
 }
 
-// // DecryptArmoredStreamUnverified decrypts encrypted armored stream using pgp keys, returning a decrypted stream
-// // * message    : The encrypted armored input as a io.Reader
-// // Any signature is ignored
-// func (keyRing *KeyRing) DecryptArmoredStreamUnverified(
-// 	encryptedIO io.Reader, privateKey *KeyRing,
-// ) (message io.Reader, err error) {
-// 	unarmored, err := armor.Decode(message)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return keyRing.DecryptUnarmoredStreamUnverified(unarmored)
-// }
+// DecryptArmoredStreamUnverified decrypts encrypted armored stream using pgp keys, returning a decrypted stream
+// * message    : The encrypted armored input as a io.Reader
+// Any signature is ignored
+func (keyRing *KeyRing) DecryptArmoredStreamUnverified(
+	encryptedIO io.Reader, privateKey *KeyRing,
+) (message io.Reader, err error) {
+	unarmored, err := armor.Decode(message)
+	if err != nil {
+		return nil, err
+	}
+	return keyRing.DecryptUnarmoredStreamUnverified(unarmored.Body)
+}
 
 // SignDetached generates and returns a PGPSignature for a given PlainMessage.
 func (keyRing *KeyRing) SignDetached(message *PlainMessage) (*PGPSignature, error) {

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -59,6 +59,37 @@ func (keyRing *KeyRing) Decrypt(
 	return asymmetricDecrypt(message.NewReader(), keyRing, verifyKey, verifyTime)
 }
 
+// DecryptUnarmoredStreamUnverified decrypts encrypted binary stream using pgp keys, returning a decrypted stream
+// * message    : The encrypted binary input as a io.Reader
+// Any signature is ignored
+func (keyRing *KeyRing) DecryptUnarmoredStreamUnverified(
+	encryptedIO io.Reader,
+) (message io.Reader, err error) {
+	privKeyEntries := keyRing.entities
+
+	config := &packet.Config{Time: getTimeGenerator()}
+
+	messageDetails, err := openpgp.ReadMessage(encryptedIO, privKeyEntries, nil, config)
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: error in reading message")
+	}
+
+	return messageDetails.UnverifiedBody, nil
+}
+
+// // DecryptArmoredStreamUnverified decrypts encrypted armored stream using pgp keys, returning a decrypted stream
+// // * message    : The encrypted armored input as a io.Reader
+// // Any signature is ignored
+// func (keyRing *KeyRing) DecryptArmoredStreamUnverified(
+// 	encryptedIO io.Reader, privateKey *KeyRing,
+// ) (message io.Reader, err error) {
+// 	unarmored, err := armor.Decode(message)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return keyRing.DecryptUnarmoredStreamUnverified(unarmored)
+// }
+
 // SignDetached generates and returns a PGPSignature for a given PlainMessage.
 func (keyRing *KeyRing) SignDetached(message *PlainMessage) (*PGPSignature, error) {
 	signEntity, err := keyRing.getSigningEntity()

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -63,9 +63,7 @@ func (keyRing *KeyRing) Decrypt(
 // DecryptUnarmoredStreamUnverified decrypts encrypted binary stream using pgp keys, returning a decrypted stream
 // * message    : The encrypted binary input as a io.Reader
 // Any signature is ignored
-func (keyRing *KeyRing) DecryptUnarmoredStreamUnverified(
-	encryptedIO io.Reader,
-) (message io.Reader, err error) {
+func (keyRing *KeyRing) DecryptUnarmoredStreamUnverified(encryptedIO io.Reader) (message io.Reader, err error) {
 	privKeyEntries := keyRing.entities
 
 	config := &packet.Config{Time: getTimeGenerator()}
@@ -81,10 +79,8 @@ func (keyRing *KeyRing) DecryptUnarmoredStreamUnverified(
 // DecryptArmoredStreamUnverified decrypts encrypted armored stream using pgp keys, returning a decrypted stream
 // * message    : The encrypted armored input as a io.Reader
 // Any signature is ignored
-func (keyRing *KeyRing) DecryptArmoredStreamUnverified(
-	encryptedIO io.Reader, privateKey *KeyRing,
-) (message io.Reader, err error) {
-	unarmored, err := armor.Decode(message)
+func (keyRing *KeyRing) DecryptArmoredStreamUnverified(encryptedIO io.Reader) (io.Reader, error) {
+	unarmored, err := armor.Decode(encryptedIO)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Introduce two KeyRing methods that does stream decryption, taking a io.Reader for either an armored or unarmored pgpMessage.
It returns a io.Reader for the decrypted data.

