### PR TITLE
Removed the cloning of the final data in the attachment processor

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,8 @@ linters-settings:
     lines: 100
     statements: 80
   cyclop:
-    # the maximal code complexity to report
-    max-complexity: 20
+    # the minimal code complexity to report
+    min-complexity: 20
 
 issues:
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,9 @@ linters-settings:
   funlen:
     lines: 100
     statements: 80
+  cyclop:
+    # the maximal code complexity to report
+    max-complexity: 20
 
 issues:
   exclude-use-default: false
@@ -33,3 +36,4 @@ linters:
     - paralleltest      # Detects missing usage of t.Parallel() method in your Go test
     - forbidigo         # Static analysis tool to forbid use of particular identifiers
     - thelper           # Enforce test helper formatting
+    - revive            # Force CamelCase instead of all caps

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
     statements: 80
   cyclop:
     # the minimal code complexity to report
-    min-complexity: 20
+    max-complexity: 20
 
 issues:
   exclude-use-default: false
@@ -37,3 +37,4 @@ linters:
     - forbidigo         # Static analysis tool to forbid use of particular identifiers
     - thelper           # Enforce test helper formatting
     - revive            # Force CamelCase instead of all caps
+    - cyclop            # Temp disabling because of a bug that ignores the setting TODO : enable it once the fix as been released

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Changed
+- Removed an unecessary cloning in the attachment processor, to perform better in low memory settings
+
 ## [2.1.4] 2021-01-08
 ### Added
 - Methods for generating an verifying encrypted detached signatures

--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -90,7 +90,9 @@ func (keyRing *KeyRing) newAttachmentProcessor(
 	go func() {
 		defer attachmentProc.done.Done()
 		ciphertext, _ := ioutil.ReadAll(reader)
-		message := NewPGPMessage(ciphertext)
+		message := &PGPMessage{
+			Data: ciphertext,
+		}
 		split, splitError := message.SeparateKeyAndData(estimatedSize, garbageCollector)
 		if attachmentProc.err != nil {
 			attachmentProc.err = splitError

--- a/crypto/keyring.go
+++ b/crypto/keyring.go
@@ -130,7 +130,7 @@ func (keyRing *KeyRing) GetKeyIDs() []uint64 {
 // parts of these KeyRings.
 func FilterExpiredKeys(contactKeys []*KeyRing) (filteredKeys []*KeyRing, err error) {
 	now := time.Now()
-	hasExpiredEntity := false
+	hasExpiredEntity := false //nolint:ifshort
 	filteredKeys = make([]*KeyRing, 0)
 
 	for _, contactKeyRing := range contactKeys {


### PR DESCRIPTION
The attachment processor was taking too much memory to be used in some settings (eg ios sharing extensions).
In this PR I removed the cloning of the final ciphertext data to create the PGPMessage.

I believe this cloning was used to protect from garbage collection of binary data given by the app to golang, while it's used in golang.

But in this situation, it's the other way around, golang is giving binary data to the app, so it's not needed.

