### PR TITLE
Release version 2.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.7] 2021-03-30
 
 ### Added 
 - `ManualAttachmentProcessor`: a new kind of attachment processor where the caller has to first allocate a buffer large enough for the whole data packet to be written to. It can be created with 

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,7 +3,7 @@ package constants
 
 // Constants for armored data.
 const (
-	ArmorHeaderVersion = "GopenPGP 2.1.5"
+	ArmorHeaderVersion = "GopenPGP 2.1.7"
 	ArmorHeaderComment = "https://gopenpgp.org"
 	PGPMessageHeader   = "PGP MESSAGE"
 	PGPSignatureHeader = "PGP SIGNATURE"

--- a/constants/version.go
+++ b/constants/version.go
@@ -1,3 +1,3 @@
 package constants
 
-const Version = "2.1.5"
+const Version = "2.1.7"


### PR DESCRIPTION
Add `ManualAttachmentProcessor` for manual memory management and add support mobile building with go 1.16