### PR TITLE
Update error messages in `passwordDecrypt`

### DIFF
--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -18,7 +18,7 @@ func TestAESEncryption(t *testing.T) {
 	}
 
 	_, err = DecryptMessageWithPassword([]byte("Wrong passphrase"), ciphertext)
-	assert.NotNil(t, err)
+	assert.Containsf(t, err.Error(), "wrong password", "expected error containing 'wrong password', got %s", err)
 
 	decrypted, err := DecryptMessageWithPassword(passphrase, ciphertext)
 	if err != nil {


### PR DESCRIPTION
Return more relevant error messages in `passwordDecrypt`, following the changes in https://github.com/ProtonMail/go-crypto/pull/71.

TODO:

- [x] waiting for release of https://github.com/ProtonMail/go-crypto/pull/78 .