### PR TITLE
Add a streaming api to KeyRing and SessionKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Streaming API:
 	- New structs:
-		- `PlainMessageMetadata`:
+		- `PlainMessageMetadata`: holds the metadata of a plain PGP message
 			```go
 			type PlainMessageMetadata struct {
 				IsBinary bool
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 				verifyTime int64,
 			) (plainMessage *PlainMessageReader, err error)
 			```
-		
+			N.B.: to verify the signature, you will need to call `plainMessage.VerifySignature()` after all the data has been read from `plainMessage`.
 		- Decrypt (and optionally verify) a split message, getting the datapacket from a `Reader`:
 			```go
 			func (keyRing *KeyRing) DecryptSplitStream(
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 				verifyKeyRing *KeyRing, verifyTime int64,
 			) (plainMessage *PlainMessageReader, err error)
 			```
+			N.B.: to verify the signature, you will need to call `plainMessage.VerifySignature()` after all the data has been read from `plainMessage`.
 		- Generate a detached signature from a `Reader`:
 			```go
 			func (keyRing *KeyRing) SignDetachedStream(message Reader) (*PGPSignature, error)
@@ -105,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 				verifyTime int64,
 			) (plainMessage *PlainMessageReader, err error)
 			```
+			N.B.: to verify the signature, you will need to call `plainMessage.VerifySignature()` after all the data has been read from `plainMessage`.
 	- Mobile apps helpers for `Reader` and `Writer`: 
 		Due to limitations of `gomobile`, mobile apps can't implement the `Reader` and `Writer` interfaces directly.
 		
@@ -128,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 		- Using a `Reader`: To use a reader returned by golang in mobile apps: you should wrap it with:
 			- Android: `Go2AndroidReader(reader)`, implements the `Reader` interface, but returns `n == -1` instead of `err == io.EOF`
 			- iOS: `Go2IOSReader(reader)`, implements `MobileReader`.
+		- Using a `Writer`: you can use a writer returned by golang directly.
 ## [2.1.10] 2021-06-16
 ### Fixed
 - Removed time interpolation via monotonic clock that can cause signatures in the future

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -119,7 +119,7 @@ func (keyRing *KeyRing) VerifyDetachedEncrypted(message *PlainMessage, encrypted
 
 // ------ INTERNAL FUNCTIONS -------
 
-// Core for encryption+signature functions.
+// Core for encryption+signature (non-streaming) functions.
 func asymmetricEncrypt(
 	plainMessage *PlainMessage,
 	publicKey, privateKey *KeyRing,
@@ -153,6 +153,7 @@ func asymmetricEncrypt(
 	return outBuf.Bytes(), nil
 }
 
+// Core for encryption+signature (all) functions.
 func asymmetricEncryptStream(
 	hints *openpgp.FileHints,
 	keyPacketWriter io.Writer,
@@ -181,7 +182,7 @@ func asymmetricEncryptStream(
 	return encryptWriter, nil
 }
 
-// Core for decryption+verification functions.
+// Core for decryption+verification (non streaming) functions.
 func asymmetricDecrypt(
 	encryptedIO io.Reader, privateKey *KeyRing, verifyKey *KeyRing, verifyTime int64,
 ) (message *PlainMessage, err error) {
@@ -212,7 +213,7 @@ func asymmetricDecrypt(
 	}, err
 }
 
-// Core for decryption+verification functions.
+// Core for decryption+verification (all) functions.
 func asymmetricDecryptStream(
 	encryptedIO io.Reader, privateKey *KeyRing, verifyKey *KeyRing,
 ) (messageDetails *openpgp.MessageDetails, err error) {

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -155,8 +155,8 @@ func asymmetricEncrypt(
 
 func asymmetricEncryptStream(
 	hints *openpgp.FileHints,
-	dataPacketWriter io.Writer,
 	keyPacketWriter io.Writer,
+	dataPacketWriter io.Writer,
 	publicKey, privateKey *KeyRing,
 	config *packet.Config,
 ) (encryptWriter io.WriteCloser, err error) {

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -137,7 +137,7 @@ func asymmetricEncrypt(
 
 	encryptWriter, err = asymmetricEncryptStream(hints, &outBuf, &outBuf, publicKey, privateKey, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: error in encrypting asymmetrically")
+		return nil, err
 	}
 
 	_, err = encryptWriter.Write(plainMessage.GetBinary())
@@ -191,7 +191,7 @@ func asymmetricDecrypt(
 		verifyKey,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: error in reading message")
+		return nil, err
 	}
 
 	body, err := ioutil.ReadAll(messageDetails.UnverifiedBody)

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -135,7 +135,7 @@ func asymmetricEncrypt(
 		ModTime:  plainMessage.getFormattedTime(),
 	}
 
-	encryptWriter, err = asymmetricEncryptStream(hints, &outBuf, publicKey, privateKey, config)
+	encryptWriter, err = asymmetricEncryptStream(hints, &outBuf, &outBuf, publicKey, privateKey, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: error in encrypting asymmetrically")
 	}
@@ -155,7 +155,8 @@ func asymmetricEncrypt(
 
 func asymmetricEncryptStream(
 	hints *openpgp.FileHints,
-	outWriter io.Writer,
+	dataPacketWriter io.Writer,
+	keyPacketWriter io.Writer,
 	publicKey, privateKey *KeyRing,
 	config *packet.Config,
 ) (encryptWriter io.WriteCloser, err error) {
@@ -170,9 +171,9 @@ func asymmetricEncryptStream(
 	}
 
 	if hints.IsBinary {
-		encryptWriter, err = openpgp.Encrypt(outWriter, publicKey.entities, signEntity, hints, config)
+		encryptWriter, err = openpgp.EncryptSplit(keyPacketWriter, dataPacketWriter, publicKey.entities, signEntity, hints, config)
 	} else {
-		encryptWriter, err = openpgp.EncryptText(outWriter, publicKey.entities, signEntity, hints, config)
+		encryptWriter, err = openpgp.EncryptTextSplit(keyPacketWriter, dataPacketWriter, publicKey.entities, signEntity, hints, config)
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: error in encrypting asymmetrically")

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -35,7 +35,7 @@ func NewPlainMessageMetadata(isBinary bool, filename string, modTime int64) *Pla
 }
 
 // EncryptStream is used to encrypt data as a Writer.
-// It takes a writer for the encrypted data and returns a writer for the plaintext data
+// It takes a writer for the encrypted data and returns a WriteCloser for the plaintext data
 // If signKeyRing is not nil, it is used to do an embedded signature.
 func (keyRing *KeyRing) EncryptStream(
 	pgpMessageWriter Writer,

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -19,13 +19,18 @@ type Writer interface {
 	Write([]byte) (int, error)
 }
 
+type WriteCloser interface {
+	Write([]byte) (int, error)
+	Close() error
+}
+
 func (keyRing *KeyRing) EncryptStream(
 	pgpMessageWriter Writer,
 	isBinary bool,
 	filename string,
 	modTime int64,
 	privateKey *KeyRing,
-) (plainMessageWriter Writer, err error) {
+) (plainMessageWriter WriteCloser, err error) {
 	config := &packet.Config{DefaultCipher: packet.CipherAES256, Time: getTimeGenerator()}
 	var signEntity *openpgp.Entity
 

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -44,12 +44,19 @@ func (keyRing *KeyRing) EncryptStream(
 ) (plainMessageWriter WriteCloser, err error) {
 	config := &packet.Config{DefaultCipher: packet.CipherAES256, Time: getTimeGenerator()}
 
-	hints := &openpgp.FileHints{}
+	if plainMessageMetadata == nil {
+		// Use sensible default metadata
+		plainMessageMetadata = &PlainMessageMetadata{
+			IsBinary: true,
+			Filename: "",
+			ModTime:  GetUnixTime(),
+		}
+	}
 
-	if plainMessageMetadata != nil {
-		hints.FileName = plainMessageMetadata.Filename
-		hints.IsBinary = plainMessageMetadata.IsBinary
-		hints.ModTime = time.Unix(plainMessageMetadata.ModTime, 0)
+	hints := &openpgp.FileHints{
+		FileName: plainMessageMetadata.Filename,
+		IsBinary: plainMessageMetadata.IsBinary,
+		ModTime:  time.Unix(plainMessageMetadata.ModTime, 0),
 	}
 
 	plainMessageWriter, err = asymmetricEncryptStream(hints, pgpMessageWriter, pgpMessageWriter, keyRing, signKeyRing, config)
@@ -102,12 +109,19 @@ func (keyRing *KeyRing) EncryptSplitStream(
 ) (*EncryptSplitResult, error) {
 	config := &packet.Config{DefaultCipher: packet.CipherAES256, Time: getTimeGenerator()}
 
-	hints := &openpgp.FileHints{}
+	if plainMessageMetadata == nil {
+		// Use sensible default metadata
+		plainMessageMetadata = &PlainMessageMetadata{
+			IsBinary: true,
+			Filename: "",
+			ModTime:  GetUnixTime(),
+		}
+	}
 
-	if plainMessageMetadata != nil {
-		hints.FileName = plainMessageMetadata.Filename
-		hints.IsBinary = plainMessageMetadata.IsBinary
-		hints.ModTime = time.Unix(plainMessageMetadata.ModTime, 0)
+	hints := &openpgp.FileHints{
+		FileName: plainMessageMetadata.Filename,
+		IsBinary: plainMessageMetadata.IsBinary,
+		ModTime:  time.Unix(plainMessageMetadata.ModTime, 0),
 	}
 
 	var keyPacketBuf bytes.Buffer

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -169,11 +169,13 @@ func (msg *PlainMessageReader) Read(b []byte) (n int, err error) {
 // or if the message hasn't been read entirely.
 func (msg *PlainMessageReader) VerifySignature() (err error) {
 	if !msg.readAll {
-		return errors.New("gopenpg: can't verify the signature until the message reader has been read entirely")
+		return errors.New("gopenpgp: can't verify the signature until the message reader has been read entirely")
 	}
 	if msg.verifyKeyRing != nil {
 		processSignatureExpiration(msg.details, msg.verifyTime)
 		err = verifyDetailsSignature(msg.details, msg.verifyKeyRing)
+	} else {
+		err = errors.New("gopenpgp: no verify keyring was provided before decryption")
 	}
 	return
 }

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -15,15 +15,15 @@ func IsEOF(err error) bool {
 }
 
 type Reader interface {
-	Read([]byte) (int, error)
+	Read(b []byte) (n int, err error)
 }
 
 type Writer interface {
-	Write([]byte) (int, error)
+	Write(b []byte) (n int, err error)
 }
 
 type WriteCloser interface {
-	Write([]byte) (int, error)
+	Write(b []byte) (n int, err error)
 	Close() error
 }
 

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -81,7 +81,8 @@ func (res *EncryptSplitResult) GetKeyPacket() (keyPacket []byte, err error) {
 }
 
 // EncryptSplitStream is used to encrypt data as a stream.
-// It takes a writer for the encrypted data packet
+// It takes a writer for the Symmetrically Encrypted Data Packet
+// (https://datatracker.ietf.org/doc/html/rfc4880#section-5.7)
 // and returns a writer for the plaintext data and the key packet.
 // If signKeyRing is not nil, it is used to do an embedded signature.
 func (keyRing *KeyRing) EncryptSplitStream(

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -73,7 +73,7 @@ func (res *EncryptSplitResult) Close() (err error) {
 
 func (res *EncryptSplitResult) GetKeyPacket() (keyPacket []byte, err error) {
 	if !res.isClosed {
-		return nil, errors.New("gopenpg: can't access key packet until the message writer has been closed")
+		return nil, errors.New("gopenpgp: can't access key packet until the message writer has been closed")
 	}
 	return res.keyPacket, nil
 }

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -1,0 +1,96 @@
+package crypto
+
+import (
+	"io"
+	"time"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/pkg/errors"
+)
+
+var EOF = io.EOF
+
+type Reader interface {
+	Read([]byte) (int, error)
+}
+
+type Writer interface {
+	Write([]byte) (int, error)
+}
+
+func (keyRing *KeyRing) EncryptStream(
+	pgpMessageWriter Writer,
+	isBinary bool,
+	filename string,
+	modTime int64,
+	privateKey *KeyRing,
+) (plainMessageWriter Writer, err error) {
+	config := &packet.Config{DefaultCipher: packet.CipherAES256, Time: getTimeGenerator()}
+	var signEntity *openpgp.Entity
+
+	if privateKey != nil && len(privateKey.entities) > 0 {
+		var err error
+		signEntity, err = privateKey.getSigningEntity()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	hints := &openpgp.FileHints{
+		IsBinary: isBinary,
+		FileName: filename,
+		ModTime:  time.Unix(modTime, 0),
+	}
+
+	if isBinary {
+		plainMessageWriter, err = openpgp.Encrypt(pgpMessageWriter, keyRing.entities, signEntity, hints, config)
+	} else {
+		plainMessageWriter, err = openpgp.EncryptText(pgpMessageWriter, keyRing.entities, signEntity, hints, config)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: error in encrypting asymmetrically")
+	}
+	return plainMessageWriter, nil
+}
+
+type PlainMessageReader struct {
+	Data     Reader
+	TextType bool
+	Filename string
+	Time     uint32
+}
+
+func (keyRing *KeyRing) DecryptStream(
+	message Reader, verifyKey *KeyRing, verifyTime int64,
+) (plainMessage *PlainMessageReader, err error) {
+	privKeyEntries := keyRing.entities
+	var additionalEntries openpgp.EntityList
+
+	if verifyKey != nil {
+		additionalEntries = verifyKey.entities
+	}
+
+	if additionalEntries != nil {
+		privKeyEntries = append(privKeyEntries, additionalEntries...)
+	}
+
+	config := &packet.Config{Time: getTimeGenerator()}
+
+	messageDetails, err := openpgp.ReadMessage(message, privKeyEntries, nil, config)
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: error in reading message")
+	}
+
+	if verifyKey != nil {
+		processSignatureExpiration(messageDetails, verifyTime)
+		err = verifyDetailsSignature(messageDetails, verifyKey)
+	}
+
+	return &PlainMessageReader{
+		Data:     messageDetails.UnverifiedBody,
+		TextType: !messageDetails.LiteralData.IsBinary,
+		Filename: messageDetails.LiteralData.FileName,
+		Time:     messageDetails.LiteralData.Time,
+	}, err
+}

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -11,6 +11,10 @@ import (
 
 var EOF = io.EOF
 
+func IsEOF(err error) bool {
+	return errors.Is(err, EOF)
+}
+
 type Reader interface {
 	Read([]byte) (int, error)
 }

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"fmt"
 	"io"
 	"time"
 
@@ -9,14 +10,22 @@ import (
 	"github.com/pkg/errors"
 )
 
-var EOF = io.EOF
-
 func IsEOF(err error) bool {
-	return errors.Is(err, EOF)
+	return errors.Is(err, io.EOF)
 }
 
-type Reader interface {
-	Read([]byte) (int, error)
+type GoMobileReadResult struct {
+	N     int
+	IsEOF bool
+	Data  []byte
+}
+
+func NewGoMobileReadResult(n int, eof bool, data []byte) *GoMobileReadResult {
+	return &GoMobileReadResult{n, eof, data}
+}
+
+type GoMobileReader interface {
+	Read(int) (*GoMobileReadResult, error)
 }
 
 type Writer interface {
@@ -64,14 +73,62 @@ func (keyRing *KeyRing) EncryptStream(
 }
 
 type PlainMessageReader struct {
-	Data     Reader
+	Data     GoMobileReader
 	TextType bool
 	Filename string
 	Time     uint32
 }
 
+type BridgingNative2GoReader struct {
+	reader GoMobileReader
+}
+
+func (d *BridgingNative2GoReader) Read(b []byte) (int, error) {
+	result, err := d.reader.Read(len(b))
+	if err != nil {
+		fmt.Printf("error while reading %v\n", err)
+		return 0, err
+	}
+	n := result.N
+	fmt.Printf("Read %d\n", n)
+	if n > 0 {
+		copy(b, result.Data[:n])
+		fmt.Printf("Bytes %x\n", b[:n])
+	}
+	if result.IsEOF {
+		fmt.Println("EOF")
+		err = io.EOF
+	}
+	return n, err
+}
+
+type BridgingGo2NativeReader struct {
+	reader io.Reader
+}
+
+func (d *BridgingGo2NativeReader) Read(max int) (*GoMobileReadResult, error) {
+	b := make([]byte, max)
+	n, err := d.reader.Read(b)
+	result := &GoMobileReadResult{}
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			fmt.Println("EOF")
+			result.IsEOF = true
+		} else {
+			return nil, err
+		}
+	}
+	result.N = n
+	fmt.Printf("Read %d\n", n)
+	if n > 0 {
+		result.Data = b[:n]
+		fmt.Printf("Bytes %x\n", b[:n])
+	}
+	return result, nil
+}
+
 func (keyRing *KeyRing) DecryptStream(
-	message Reader, verifyKey *KeyRing, verifyTime int64,
+	message GoMobileReader, verifyKey *KeyRing, verifyTime int64,
 ) (plainMessage *PlainMessageReader, err error) {
 	privKeyEntries := keyRing.entities
 	var additionalEntries openpgp.EntityList
@@ -86,7 +143,7 @@ func (keyRing *KeyRing) DecryptStream(
 
 	config := &packet.Config{Time: getTimeGenerator()}
 
-	messageDetails, err := openpgp.ReadMessage(message, privKeyEntries, nil, config)
+	messageDetails, err := openpgp.ReadMessage(&BridgingNative2GoReader{message}, privKeyEntries, nil, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: error in reading message")
 	}
@@ -97,7 +154,7 @@ func (keyRing *KeyRing) DecryptStream(
 	}
 
 	return &PlainMessageReader{
-		Data:     messageDetails.UnverifiedBody,
+		Data:     &BridgingGo2NativeReader{messageDetails.UnverifiedBody},
 		TextType: !messageDetails.LiteralData.IsBinary,
 		Filename: messageDetails.LiteralData.FileName,
 		Time:     messageDetails.LiteralData.Time,

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -71,6 +71,8 @@ func (res *EncryptSplitResult) Close() (err error) {
 	return nil
 }
 
+// GetKeyPacket returns the Public-Key Encrypted Session Key Packets (https://datatracker.ietf.org/doc/html/rfc4880#section-5.1).
+// This can be retrieved only after the message has been fully written and the writer is closed.
 func (res *EncryptSplitResult) GetKeyPacket() (keyPacket []byte, err error) {
 	if !res.isClosed {
 		return nil, errors.New("gopenpgp: can't access key packet until the message writer has been closed")

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -130,7 +130,7 @@ type PlainMessageReader struct {
 	readAll       bool
 }
 
-// IsBinary returns whether the message is binary or text.
+// GetMetadata returns the metadata of the decrypted message.
 func (msg *PlainMessageReader) GetMetadata() *PlainMessageMetadata {
 	return &PlainMessageMetadata{
 		Filename: msg.details.LiteralData.FileName,

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -44,7 +44,7 @@ func (keyRing *KeyRing) EncryptStream(
 
 	plainMessageWriter, err = asymmetricEncryptStream(hints, pgpMessageWriter, pgpMessageWriter, keyRing, signKeyRing, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: error in encrypting asymmetrically")
+		return nil, err
 	}
 	return plainMessageWriter, nil
 }
@@ -99,7 +99,7 @@ func (keyRing *KeyRing) EncryptSplitStream(
 	var keyPacketBuf bytes.Buffer
 	plainMessageWriter, err := asymmetricEncryptStream(hints, &keyPacketBuf, dataPacketWriter, keyRing, signKeyRing, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: error in encrypting asymmetrically")
+		return nil, err
 	}
 	return &EncryptSplitResult{
 		keyPacketBuf:       &keyPacketBuf,
@@ -172,7 +172,7 @@ func (keyRing *KeyRing) DecryptStream(
 		verifyKeyRing,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: error in reading message")
+		return nil, err
 	}
 
 	return &PlainMessageReader{

--- a/crypto/keyring_streaming_test.go
+++ b/crypto/keyring_streaming_test.go
@@ -1,0 +1,235 @@
+package crypto
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestKeyRing_EncryptStream(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	var ciphertextBuf bytes.Buffer
+	isBinary := true
+	filename := "filename.txt"
+	modTime := GetUnixTime()
+	messageWriter, err := keyRingPublic.EncryptStream(
+		&ciphertextBuf,
+		isBinary,
+		filename,
+		modTime,
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling EncryptStream, got:", err)
+	}
+	reachedEnd := false
+	bufferSize := 2
+	buffer := make([]byte, bufferSize)
+	for !reachedEnd {
+		n, err := messageReader.Read(buffer)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading data, got:", err)
+			}
+		}
+		writtenTotal := 0
+		for writtenTotal < n {
+			written, err := messageWriter.Write(buffer[writtenTotal:n])
+			if err != nil {
+				t.Fatal("Expected no error while writing data, got:", err)
+			}
+			writtenTotal += written
+		}
+	}
+	err = messageWriter.Close()
+	if err != nil {
+		t.Fatal("Expected no error while closing plaintext writer, got:", err)
+	}
+	decryptedReader, err := keyRingPrivate.DecryptStream(
+		&ciphertextBuf,
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling DecryptStream, got:", err)
+	}
+	decryptedBytes, err := io.ReadAll(decryptedReader)
+	if err != nil {
+		t.Fatal("Expected no error while reading the decrypted data, got:", err)
+	}
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	err = decryptedReader.VerifySignature()
+	if err != nil {
+		t.Fatal("Expected no error while verifying the signature, got:", err)
+	}
+	if isBinary != decryptedReader.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
+	}
+	if filename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", filename, decryptedReader.GetFilename())
+	}
+	if modTime != decryptedReader.GetModificationTime() {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	}
+}
+
+func TestKeyRing_EncryptSplitStream(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	var dataPacketBuf bytes.Buffer
+	isBinary := true
+	filename := "filename.txt"
+	modTime := GetUnixTime()
+	encryptionResult, err := keyRingPublic.EncryptSplitStream(
+		&dataPacketBuf,
+		isBinary,
+		filename,
+		modTime,
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling EncryptStream, got:", err)
+	}
+	messageWriter := encryptionResult
+	reachedEnd := false
+	bufferSize := 2
+	buffer := make([]byte, bufferSize)
+	for !reachedEnd {
+		n, err := messageReader.Read(buffer)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading data, got:", err)
+			}
+		}
+		writtenTotal := 0
+		for writtenTotal < n {
+			written, err := messageWriter.Write(buffer[writtenTotal:n])
+			if err != nil {
+				t.Fatal("Expected no error while writing data, got:", err)
+			}
+			writtenTotal += written
+		}
+	}
+	err = messageWriter.Close()
+	if err != nil {
+		t.Fatal("Expected no error while closing plaintext writer, got:", err)
+	}
+	keyPacket, err := encryptionResult.GetKeyPacket()
+	if err != nil {
+		t.Fatal("Expected no error while accessing key packet, got:", err)
+	}
+	dataPacket := dataPacketBuf.Bytes()
+	pgpSplit := PGPSplitMessage{keyPacket, dataPacket}
+	plainMessage, err := keyRingPrivate.Decrypt(pgpSplit.GetPGPMessage(), nil, 0)
+	if err != nil {
+		t.Fatal("Expected no error while decrypting normally, got:", err)
+	}
+	decryptedBytes := plainMessage.Data
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the normally decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	decryptedReader, err := keyRingPrivate.DecryptSplitStream(
+		keyPacket,
+		bytes.NewReader(dataPacket),
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling DecryptStream, got:", err)
+	}
+	decryptedBytes, err = io.ReadAll(decryptedReader)
+	if err != nil {
+		t.Fatal("Expected no error while reading the decrypted data, got:", err)
+	}
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	err = decryptedReader.VerifySignature()
+	if err != nil {
+		t.Fatal("Expected no error while verifying the signature, got:", err)
+	}
+	if isBinary != decryptedReader.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
+	}
+	if filename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", filename, decryptedReader.GetFilename())
+	}
+	if modTime != decryptedReader.GetModificationTime() {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	}
+}
+
+func TestKeyRing_SignDetachedStream(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	signature, err := keyRingPrivate.SignDetachedStream(messageReader)
+	if err != nil {
+		t.Fatal("Expected no error while signing the message, got:", err)
+	}
+	_, err = messageReader.Seek(0, 0)
+	if err != nil {
+		t.Fatal("Expected no error while rewinding the message reader, got:", err)
+	}
+	err = keyRingPublic.VerifyDetachedStream(messageReader, signature, GetUnixTime())
+	if err != nil {
+		t.Fatal("Expected no error while verifying the detached signature, got:", err)
+	}
+}
+
+func TestKeyRing_SignDetachedEncryptedStream(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	encSignature, err := keyRingPrivate.SignDetachedEncryptedStream(messageReader, keyRingPublic)
+	if err != nil {
+		t.Fatal("Expected no error while signing the message, got:", err)
+	}
+	_, err = messageReader.Seek(0, 0)
+	if err != nil {
+		t.Fatal("Expected no error while rewinding the message reader, got:", err)
+	}
+	err = keyRingPublic.VerifyDetachedEncryptedStream(messageReader, encSignature, keyRingPrivate, GetUnixTime())
+	if err != nil {
+		t.Fatal("Expected no error while verifying the detached signature, got:", err)
+	}
+}

--- a/crypto/keyring_streaming_test.go
+++ b/crypto/keyring_streaming_test.go
@@ -11,25 +11,17 @@ import (
 const testFilename = "filename.txt"
 
 func TestKeyRing_EncryptDecryptStream(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var ciphertextBuf bytes.Buffer
 	isBinary := true
 	modTime := GetUnixTime()
-	messageWriter, err := keyRingPublic.EncryptStream(
+	messageWriter, err := keyRingTestPublic.EncryptStream(
 		&ciphertextBuf,
 		isBinary,
 		testFilename,
 		modTime,
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while encrypting stream with key ring, got:", err)
@@ -59,9 +51,9 @@ func TestKeyRing_EncryptDecryptStream(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while closing plaintext writer, got:", err)
 	}
-	decryptedReader, err := keyRingPrivate.DecryptStream(
+	decryptedReader, err := keyRingTestPrivate.DecryptStream(
 		&ciphertextBuf,
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {
@@ -90,25 +82,17 @@ func TestKeyRing_EncryptDecryptStream(t *testing.T) {
 }
 
 func TestKeyRing_EncryptStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var ciphertextBuf bytes.Buffer
 	isBinary := true
 	modTime := GetUnixTime()
-	messageWriter, err := keyRingPublic.EncryptStream(
+	messageWriter, err := keyRingTestPublic.EncryptStream(
 		&ciphertextBuf,
 		isBinary,
 		testFilename,
 		modTime,
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while encrypting stream with key ring, got:", err)
@@ -139,9 +123,9 @@ func TestKeyRing_EncryptStreamCompatible(t *testing.T) {
 		t.Fatal("Expected no error while closing plaintext writer, got:", err)
 	}
 	encryptedData := ciphertextBuf.Bytes()
-	decryptedMsg, err := keyRingPrivate.Decrypt(
+	decryptedMsg, err := keyRingTestPrivate.Decrypt(
 		NewPGPMessage(encryptedData),
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {
@@ -163,26 +147,18 @@ func TestKeyRing_EncryptStreamCompatible(t *testing.T) {
 }
 
 func TestKeyRing_DecryptStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	modTime := GetUnixTime()
-	pgpMessage, err := keyRingPublic.Encrypt(
+	pgpMessage, err := keyRingTestPublic.Encrypt(
 		NewPlainMessageFromFile(messageBytes, testFilename, uint32(modTime)),
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while encrypting plaintext, got:", err)
 	}
-	decryptedReader, err := keyRingPrivate.DecryptStream(
+	decryptedReader, err := keyRingTestPrivate.DecryptStream(
 		bytes.NewReader(pgpMessage.GetBinary()),
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {
@@ -211,25 +187,17 @@ func TestKeyRing_DecryptStreamCompatible(t *testing.T) {
 }
 
 func TestKeyRing_EncryptDecryptSplitStream(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var dataPacketBuf bytes.Buffer
 	isBinary := true
 	modTime := GetUnixTime()
-	encryptionResult, err := keyRingPublic.EncryptSplitStream(
+	encryptionResult, err := keyRingTestPublic.EncryptSplitStream(
 		&dataPacketBuf,
 		isBinary,
 		testFilename,
 		modTime,
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while calling encrypting split stream with key ring, got:", err)
@@ -265,10 +233,10 @@ func TestKeyRing_EncryptDecryptSplitStream(t *testing.T) {
 		t.Fatal("Expected no error while accessing key packet, got:", err)
 	}
 	dataPacket := dataPacketBuf.Bytes()
-	decryptedReader, err := keyRingPrivate.DecryptSplitStream(
+	decryptedReader, err := keyRingTestPrivate.DecryptSplitStream(
 		keyPacket,
 		bytes.NewReader(dataPacket),
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {
@@ -297,25 +265,17 @@ func TestKeyRing_EncryptDecryptSplitStream(t *testing.T) {
 }
 
 func TestKeyRing_EncryptSplitStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var dataPacketBuf bytes.Buffer
 	isBinary := true
 	modTime := GetUnixTime()
-	encryptionResult, err := keyRingPublic.EncryptSplitStream(
+	encryptionResult, err := keyRingTestPublic.EncryptSplitStream(
 		&dataPacketBuf,
 		isBinary,
 		testFilename,
 		modTime,
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while calling encrypting split stream with key ring, got:", err)
@@ -351,9 +311,9 @@ func TestKeyRing_EncryptSplitStreamCompatible(t *testing.T) {
 		t.Fatal("Expected no error while accessing key packet, got:", err)
 	}
 	dataPacket := dataPacketBuf.Bytes()
-	decryptedMsg, err := keyRingPrivate.Decrypt(
+	decryptedMsg, err := keyRingTestPrivate.Decrypt(
 		NewPGPSplitMessage(keyPacket, dataPacket).GetPGPMessage(),
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {
@@ -378,19 +338,11 @@ func TestKeyRing_EncryptSplitStreamCompatible(t *testing.T) {
 }
 
 func TestKeyRing_DecryptSplitStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	modTime := GetUnixTime()
-	pgpMessage, err := keyRingPublic.Encrypt(
+	pgpMessage, err := keyRingTestPublic.Encrypt(
 		NewPlainMessageFromFile(messageBytes, testFilename, uint32(modTime)),
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while encrypting plaintext, got:", err)
@@ -408,10 +360,10 @@ func TestKeyRing_DecryptSplitStreamCompatible(t *testing.T) {
 		t.Fatal("Expected no error while accessing key packet, got:", err)
 	}
 	dataPacket := splitMsg.DataPacket
-	decryptedReader, err := keyRingPrivate.DecryptSplitStream(
+	decryptedReader, err := keyRingTestPrivate.DecryptSplitStream(
 		keyPacket,
 		bytes.NewReader(dataPacket),
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {
@@ -440,17 +392,9 @@ func TestKeyRing_DecryptSplitStreamCompatible(t *testing.T) {
 }
 
 func TestKeyRing_SignVerifyDetachedStream(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
-	signature, err := keyRingPrivate.SignDetachedStream(messageReader)
+	signature, err := keyRingTestPrivate.SignDetachedStream(messageReader)
 	if err != nil {
 		t.Fatal("Expected no error while signing the message, got:", err)
 	}
@@ -458,45 +402,29 @@ func TestKeyRing_SignVerifyDetachedStream(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while rewinding the message reader, got:", err)
 	}
-	err = keyRingPublic.VerifyDetachedStream(messageReader, signature, GetUnixTime())
+	err = keyRingTestPublic.VerifyDetachedStream(messageReader, signature, GetUnixTime())
 	if err != nil {
 		t.Fatal("Expected no error while verifying the detached signature, got:", err)
 	}
 }
 
 func TestKeyRing_SignDetachedStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
-	signature, err := keyRingPrivate.SignDetachedStream(messageReader)
+	signature, err := keyRingTestPrivate.SignDetachedStream(messageReader)
 	if err != nil {
 		t.Fatal("Expected no error while signing the message, got:", err)
 	}
-	err = keyRingPublic.VerifyDetached(NewPlainMessage(messageBytes), signature, GetUnixTime())
+	err = keyRingTestPublic.VerifyDetached(NewPlainMessage(messageBytes), signature, GetUnixTime())
 	if err != nil {
 		t.Fatal("Expected no error while verifying the detached signature, got:", err)
 	}
 }
 
 func TestKeyRing_VerifyDetachedStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
-	signature, err := keyRingPrivate.SignDetached(NewPlainMessage(messageBytes))
+	signature, err := keyRingTestPrivate.SignDetached(NewPlainMessage(messageBytes))
 	if err != nil {
 		t.Fatal("Expected no error while signing the message, got:", err)
 	}
@@ -504,24 +432,16 @@ func TestKeyRing_VerifyDetachedStreamCompatible(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while rewinding the message reader, got:", err)
 	}
-	err = keyRingPublic.VerifyDetachedStream(messageReader, signature, GetUnixTime())
+	err = keyRingTestPublic.VerifyDetachedStream(messageReader, signature, GetUnixTime())
 	if err != nil {
 		t.Fatal("Expected no error while verifying the detached signature, got:", err)
 	}
 }
 
 func TestKeyRing_SignVerifyDetachedEncryptedStream(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
-	encSignature, err := keyRingPrivate.SignDetachedEncryptedStream(messageReader, keyRingPublic)
+	encSignature, err := keyRingTestPrivate.SignDetachedEncryptedStream(messageReader, keyRingTestPublic)
 	if err != nil {
 		t.Fatal("Expected no error while signing the message, got:", err)
 	}
@@ -529,45 +449,29 @@ func TestKeyRing_SignVerifyDetachedEncryptedStream(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while rewinding the message reader, got:", err)
 	}
-	err = keyRingPublic.VerifyDetachedEncryptedStream(messageReader, encSignature, keyRingPrivate, GetUnixTime())
+	err = keyRingTestPublic.VerifyDetachedEncryptedStream(messageReader, encSignature, keyRingTestPrivate, GetUnixTime())
 	if err != nil {
 		t.Fatal("Expected no error while verifying the detached signature, got:", err)
 	}
 }
 
 func TestKeyRing_SignDetachedEncryptedStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
-	encSignature, err := keyRingPrivate.SignDetachedEncryptedStream(messageReader, keyRingPublic)
+	encSignature, err := keyRingTestPrivate.SignDetachedEncryptedStream(messageReader, keyRingTestPublic)
 	if err != nil {
 		t.Fatal("Expected no error while signing the message, got:", err)
 	}
-	err = keyRingPublic.VerifyDetachedEncrypted(NewPlainMessage(messageBytes), encSignature, keyRingPrivate, GetUnixTime())
+	err = keyRingTestPublic.VerifyDetachedEncrypted(NewPlainMessage(messageBytes), encSignature, keyRingTestPrivate, GetUnixTime())
 	if err != nil {
 		t.Fatal("Expected no error while verifying the detached signature, got:", err)
 	}
 }
 
 func TestKeyRing_VerifyDetachedEncryptedStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
-	encSignature, err := keyRingPrivate.SignDetachedEncrypted(NewPlainMessage(messageBytes), keyRingPublic)
+	encSignature, err := keyRingTestPrivate.SignDetachedEncrypted(NewPlainMessage(messageBytes), keyRingTestPublic)
 	if err != nil {
 		t.Fatal("Expected no error while signing the message, got:", err)
 	}
@@ -575,7 +479,7 @@ func TestKeyRing_VerifyDetachedEncryptedStreamCompatible(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while rewinding the message reader, got:", err)
 	}
-	err = keyRingPublic.VerifyDetachedEncryptedStream(messageReader, encSignature, keyRingPrivate, GetUnixTime())
+	err = keyRingTestPublic.VerifyDetachedEncryptedStream(messageReader, encSignature, keyRingTestPrivate, GetUnixTime())
 	if err != nil {
 		t.Fatal("Expected no error while verifying the detached signature, got:", err)
 	}

--- a/crypto/keyring_streaming_test.go
+++ b/crypto/keyring_streaming_test.go
@@ -10,7 +10,7 @@ import (
 
 const testFilename = "filename.txt"
 
-func TestKeyRing_EncryptStream(t *testing.T) {
+func TestKeyRing_EncryptDecryptStream(t *testing.T) {
 	keyRingPrivate, err := keyRingTestPrivate.Copy()
 	if err != nil {
 		t.Fatal("Expected no error while copying keyring, got:", err)
@@ -89,7 +89,128 @@ func TestKeyRing_EncryptStream(t *testing.T) {
 	}
 }
 
-func TestKeyRing_EncryptSplitStream(t *testing.T) {
+func TestKeyRing_EncryptStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	var ciphertextBuf bytes.Buffer
+	isBinary := true
+	modTime := GetUnixTime()
+	messageWriter, err := keyRingPublic.EncryptStream(
+		&ciphertextBuf,
+		isBinary,
+		testFilename,
+		modTime,
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while encrypting stream with key ring, got:", err)
+	}
+	reachedEnd := false
+	bufferSize := 2
+	buffer := make([]byte, bufferSize)
+	for !reachedEnd {
+		n, err := messageReader.Read(buffer)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading data, got:", err)
+			}
+		}
+		writtenTotal := 0
+		for writtenTotal < n {
+			written, err := messageWriter.Write(buffer[writtenTotal:n])
+			if err != nil {
+				t.Fatal("Expected no error while writing data, got:", err)
+			}
+			writtenTotal += written
+		}
+	}
+	err = messageWriter.Close()
+	if err != nil {
+		t.Fatal("Expected no error while closing plaintext writer, got:", err)
+	}
+	encryptedData := ciphertextBuf.Bytes()
+	decryptedMsg, err := keyRingPrivate.Decrypt(
+		NewPGPMessage(encryptedData),
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling normal decrypt with key ring, got:", err)
+	}
+	decryptedBytes := decryptedMsg.GetBinary()
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the normally decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	if isBinary != decryptedMsg.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedMsg.IsBinary())
+	}
+	if testFilename != decryptedMsg.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedMsg.GetFilename())
+	}
+	if modTime != int64(decryptedMsg.GetTime()) {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, int64(decryptedMsg.GetTime()))
+	}
+}
+
+func TestKeyRing_DecryptStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	modTime := GetUnixTime()
+	pgpMessage, err := keyRingPublic.Encrypt(
+		NewPlainMessageFromFile(messageBytes, testFilename, uint32(modTime)),
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while encrypting plaintext, got:", err)
+	}
+	decryptedReader, err := keyRingPrivate.DecryptStream(
+		bytes.NewReader(pgpMessage.GetBinary()),
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling decrypting stream with key ring, got:", err)
+	}
+	decryptedBytes, err := io.ReadAll(decryptedReader)
+	if err != nil {
+		t.Fatal("Expected no error while reading the decrypted data, got:", err)
+	}
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	err = decryptedReader.VerifySignature()
+	if err != nil {
+		t.Fatal("Expected no error while verifying the signature, got:", err)
+	}
+	if !decryptedReader.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", true, decryptedReader.IsBinary())
+	}
+	if testFilename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
+	}
+	if modTime != decryptedReader.GetModificationTime() {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	}
+}
+
+func TestKeyRing_EncryptDecryptSplitStream(t *testing.T) {
 	keyRingPrivate, err := keyRingTestPrivate.Copy()
 	if err != nil {
 		t.Fatal("Expected no error while copying keyring, got:", err)
@@ -175,7 +296,150 @@ func TestKeyRing_EncryptSplitStream(t *testing.T) {
 	}
 }
 
-func TestKeyRing_SignDetachedStream(t *testing.T) {
+func TestKeyRing_EncryptSplitStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	var dataPacketBuf bytes.Buffer
+	isBinary := true
+	modTime := GetUnixTime()
+	encryptionResult, err := keyRingPublic.EncryptSplitStream(
+		&dataPacketBuf,
+		isBinary,
+		testFilename,
+		modTime,
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling encrypting split stream with key ring, got:", err)
+	}
+	messageWriter := encryptionResult
+	reachedEnd := false
+	bufferSize := 2
+	buffer := make([]byte, bufferSize)
+	for !reachedEnd {
+		n, err := messageReader.Read(buffer)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading data, got:", err)
+			}
+		}
+		writtenTotal := 0
+		for writtenTotal < n {
+			written, err := messageWriter.Write(buffer[writtenTotal:n])
+			if err != nil {
+				t.Fatal("Expected no error while writing data, got:", err)
+			}
+			writtenTotal += written
+		}
+	}
+	err = messageWriter.Close()
+	if err != nil {
+		t.Fatal("Expected no error while closing plaintext writer, got:", err)
+	}
+	keyPacket, err := encryptionResult.GetKeyPacket()
+	if err != nil {
+		t.Fatal("Expected no error while accessing key packet, got:", err)
+	}
+	dataPacket := dataPacketBuf.Bytes()
+	decryptedMsg, err := keyRingPrivate.Decrypt(
+		NewPGPSplitMessage(keyPacket, dataPacket).GetPGPMessage(),
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while decrypting split stream with key ring, got:", err)
+	}
+	decryptedBytes := decryptedMsg.GetBinary()
+	if err != nil {
+		t.Fatal("Expected no error while reading the decrypted data, got:", err)
+	}
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	if isBinary != decryptedMsg.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedMsg.IsBinary())
+	}
+	if testFilename != decryptedMsg.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedMsg.GetFilename())
+	}
+	if modTime != int64(decryptedMsg.GetTime()) {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, int64(decryptedMsg.GetTime()))
+	}
+}
+
+func TestKeyRing_DecryptSplitStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	modTime := GetUnixTime()
+	pgpMessage, err := keyRingPublic.Encrypt(
+		NewPlainMessageFromFile(messageBytes, testFilename, uint32(modTime)),
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while encrypting plaintext, got:", err)
+	}
+	armored, err := pgpMessage.GetArmored()
+	if err != nil {
+		t.Fatal("Expected no error while armoring ciphertext, got:", err)
+	}
+	splitMsg, err := NewPGPSplitMessageFromArmored(armored)
+	if err != nil {
+		t.Fatal("Expected no error while splitting the ciphertext, got:", err)
+	}
+	keyPacket := splitMsg.KeyPacket
+	if err != nil {
+		t.Fatal("Expected no error while accessing key packet, got:", err)
+	}
+	dataPacket := splitMsg.DataPacket
+	decryptedReader, err := keyRingPrivate.DecryptSplitStream(
+		keyPacket,
+		bytes.NewReader(dataPacket),
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while decrypting split stream with key ring, got:", err)
+	}
+	decryptedBytes, err := io.ReadAll(decryptedReader)
+	if err != nil {
+		t.Fatal("Expected no error while reading the decrypted data, got:", err)
+	}
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	err = decryptedReader.VerifySignature()
+	if err != nil {
+		t.Fatal("Expected no error while verifying the signature, got:", err)
+	}
+	if !decryptedReader.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", true, decryptedReader.IsBinary())
+	}
+	if testFilename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
+	}
+	if modTime != decryptedReader.GetModificationTime() {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	}
+}
+
+func TestKeyRing_SignVerifyDetachedStream(t *testing.T) {
 	keyRingPrivate, err := keyRingTestPrivate.Copy()
 	if err != nil {
 		t.Fatal("Expected no error while copying keyring, got:", err)
@@ -200,7 +464,53 @@ func TestKeyRing_SignDetachedStream(t *testing.T) {
 	}
 }
 
-func TestKeyRing_SignDetachedEncryptedStream(t *testing.T) {
+func TestKeyRing_SignDetachedStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	signature, err := keyRingPrivate.SignDetachedStream(messageReader)
+	if err != nil {
+		t.Fatal("Expected no error while signing the message, got:", err)
+	}
+	err = keyRingPublic.VerifyDetached(NewPlainMessage(messageBytes), signature, GetUnixTime())
+	if err != nil {
+		t.Fatal("Expected no error while verifying the detached signature, got:", err)
+	}
+}
+
+func TestKeyRing_VerifyDetachedStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	signature, err := keyRingPrivate.SignDetached(NewPlainMessage(messageBytes))
+	if err != nil {
+		t.Fatal("Expected no error while signing the message, got:", err)
+	}
+	_, err = messageReader.Seek(0, 0)
+	if err != nil {
+		t.Fatal("Expected no error while rewinding the message reader, got:", err)
+	}
+	err = keyRingPublic.VerifyDetachedStream(messageReader, signature, GetUnixTime())
+	if err != nil {
+		t.Fatal("Expected no error while verifying the detached signature, got:", err)
+	}
+}
+
+func TestKeyRing_SignVerifyDetachedEncryptedStream(t *testing.T) {
 	keyRingPrivate, err := keyRingTestPrivate.Copy()
 	if err != nil {
 		t.Fatal("Expected no error while copying keyring, got:", err)
@@ -212,6 +522,52 @@ func TestKeyRing_SignDetachedEncryptedStream(t *testing.T) {
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	encSignature, err := keyRingPrivate.SignDetachedEncryptedStream(messageReader, keyRingPublic)
+	if err != nil {
+		t.Fatal("Expected no error while signing the message, got:", err)
+	}
+	_, err = messageReader.Seek(0, 0)
+	if err != nil {
+		t.Fatal("Expected no error while rewinding the message reader, got:", err)
+	}
+	err = keyRingPublic.VerifyDetachedEncryptedStream(messageReader, encSignature, keyRingPrivate, GetUnixTime())
+	if err != nil {
+		t.Fatal("Expected no error while verifying the detached signature, got:", err)
+	}
+}
+
+func TestKeyRing_SignDetachedEncryptedStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	encSignature, err := keyRingPrivate.SignDetachedEncryptedStream(messageReader, keyRingPublic)
+	if err != nil {
+		t.Fatal("Expected no error while signing the message, got:", err)
+	}
+	err = keyRingPublic.VerifyDetachedEncrypted(NewPlainMessage(messageBytes), encSignature, keyRingPrivate, GetUnixTime())
+	if err != nil {
+		t.Fatal("Expected no error while verifying the detached signature, got:", err)
+	}
+}
+
+func TestKeyRing_VerifyDetachedEncryptedStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	encSignature, err := keyRingPrivate.SignDetachedEncrypted(NewPlainMessage(messageBytes), keyRingPublic)
 	if err != nil {
 		t.Fatal("Expected no error while signing the message, got:", err)
 	}

--- a/crypto/keyring_streaming_test.go
+++ b/crypto/keyring_streaming_test.go
@@ -3,24 +3,25 @@ package crypto
 import (
 	"bytes"
 	"io"
+	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
 )
 
-const testFilename = "filename.txt"
+var testMeta = &PlainMessageMetadata{
+	IsBinary: true,
+	Filename: "filename.txt",
+	ModTime:  GetUnixTime(),
+}
 
 func TestKeyRing_EncryptDecryptStream(t *testing.T) {
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var ciphertextBuf bytes.Buffer
-	isBinary := true
-	modTime := GetUnixTime()
 	messageWriter, err := keyRingTestPublic.EncryptStream(
 		&ciphertextBuf,
-		isBinary,
-		testFilename,
-		modTime,
+		testMeta,
 		keyRingTestPrivate,
 	)
 	if err != nil {
@@ -70,14 +71,9 @@ func TestKeyRing_EncryptDecryptStream(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while verifying the signature, got:", err)
 	}
-	if isBinary != decryptedReader.IsBinary() {
-		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
-	}
-	if testFilename != decryptedReader.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
-	}
-	if modTime != decryptedReader.GetModificationTime() {
-		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	decryptedMeta := decryptedReader.GetMetadata()
+	if !reflect.DeepEqual(testMeta, decryptedMeta) {
+		t.Fatalf("Expected the decrypted metadata to be %v got %v", testMeta, decryptedMeta)
 	}
 }
 
@@ -85,13 +81,9 @@ func TestKeyRing_EncryptStreamCompatible(t *testing.T) {
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var ciphertextBuf bytes.Buffer
-	isBinary := true
-	modTime := GetUnixTime()
 	messageWriter, err := keyRingTestPublic.EncryptStream(
 		&ciphertextBuf,
-		isBinary,
-		testFilename,
-		modTime,
+		testMeta,
 		keyRingTestPrivate,
 	)
 	if err != nil {
@@ -135,22 +127,26 @@ func TestKeyRing_EncryptStreamCompatible(t *testing.T) {
 	if !bytes.Equal(decryptedBytes, messageBytes) {
 		t.Fatalf("Expected the normally decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
 	}
-	if isBinary != decryptedMsg.IsBinary() {
-		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedMsg.IsBinary())
+	if testMeta.IsBinary != decryptedMsg.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", testMeta.IsBinary, decryptedMsg.IsBinary())
 	}
-	if testFilename != decryptedMsg.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedMsg.GetFilename())
+	if testMeta.Filename != decryptedMsg.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testMeta.Filename, decryptedMsg.GetFilename())
 	}
-	if modTime != int64(decryptedMsg.GetTime()) {
-		t.Fatalf("Expected modification time to be %d got %d", modTime, int64(decryptedMsg.GetTime()))
+	if testMeta.ModTime != int64(decryptedMsg.GetTime()) {
+		t.Fatalf("Expected modification time to be %d got %d", testMeta.ModTime, int64(decryptedMsg.GetTime()))
 	}
 }
 
 func TestKeyRing_DecryptStreamCompatible(t *testing.T) {
 	messageBytes := []byte("Hello World!")
-	modTime := GetUnixTime()
 	pgpMessage, err := keyRingTestPublic.Encrypt(
-		NewPlainMessageFromFile(messageBytes, testFilename, uint32(modTime)),
+		&PlainMessage{
+			Data:     messageBytes,
+			TextType: !testMeta.IsBinary,
+			Time:     uint32(testMeta.ModTime),
+			Filename: testMeta.Filename,
+		},
 		keyRingTestPrivate,
 	)
 	if err != nil {
@@ -168,21 +164,16 @@ func TestKeyRing_DecryptStreamCompatible(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while reading the decrypted data, got:", err)
 	}
-	if !bytes.Equal(decryptedBytes, messageBytes) {
-		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
-	}
 	err = decryptedReader.VerifySignature()
 	if err != nil {
 		t.Fatal("Expected no error while verifying the signature, got:", err)
 	}
-	if !decryptedReader.IsBinary() {
-		t.Fatalf("Expected isBinary to be %t got %t", true, decryptedReader.IsBinary())
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
 	}
-	if testFilename != decryptedReader.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
-	}
-	if modTime != decryptedReader.GetModificationTime() {
-		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	decryptedMeta := decryptedReader.GetMetadata()
+	if !reflect.DeepEqual(testMeta, decryptedMeta) {
+		t.Fatalf("Expected the decrypted metadata to be %v got %v", testMeta, decryptedMeta)
 	}
 }
 
@@ -190,13 +181,9 @@ func TestKeyRing_EncryptDecryptSplitStream(t *testing.T) {
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var dataPacketBuf bytes.Buffer
-	isBinary := true
-	modTime := GetUnixTime()
 	encryptionResult, err := keyRingTestPublic.EncryptSplitStream(
 		&dataPacketBuf,
-		isBinary,
-		testFilename,
-		modTime,
+		testMeta,
 		keyRingTestPrivate,
 	)
 	if err != nil {
@@ -246,21 +233,16 @@ func TestKeyRing_EncryptDecryptSplitStream(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while reading the decrypted data, got:", err)
 	}
-	if !bytes.Equal(decryptedBytes, messageBytes) {
-		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
-	}
 	err = decryptedReader.VerifySignature()
 	if err != nil {
 		t.Fatal("Expected no error while verifying the signature, got:", err)
 	}
-	if isBinary != decryptedReader.IsBinary() {
-		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
 	}
-	if testFilename != decryptedReader.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
-	}
-	if modTime != decryptedReader.GetModificationTime() {
-		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	decryptedMeta := decryptedReader.GetMetadata()
+	if !reflect.DeepEqual(testMeta, decryptedMeta) {
+		t.Fatalf("Expected the decrypted metadata to be %v got %v", testMeta, decryptedMeta)
 	}
 }
 
@@ -268,13 +250,9 @@ func TestKeyRing_EncryptSplitStreamCompatible(t *testing.T) {
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var dataPacketBuf bytes.Buffer
-	isBinary := true
-	modTime := GetUnixTime()
 	encryptionResult, err := keyRingTestPublic.EncryptSplitStream(
 		&dataPacketBuf,
-		isBinary,
-		testFilename,
-		modTime,
+		testMeta,
 		keyRingTestPrivate,
 	)
 	if err != nil {
@@ -326,22 +304,26 @@ func TestKeyRing_EncryptSplitStreamCompatible(t *testing.T) {
 	if !bytes.Equal(decryptedBytes, messageBytes) {
 		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
 	}
-	if isBinary != decryptedMsg.IsBinary() {
-		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedMsg.IsBinary())
+	if testMeta.IsBinary != decryptedMsg.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", testMeta.IsBinary, decryptedMsg.IsBinary())
 	}
-	if testFilename != decryptedMsg.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedMsg.GetFilename())
+	if testMeta.Filename != decryptedMsg.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testMeta.Filename, decryptedMsg.GetFilename())
 	}
-	if modTime != int64(decryptedMsg.GetTime()) {
-		t.Fatalf("Expected modification time to be %d got %d", modTime, int64(decryptedMsg.GetTime()))
+	if testMeta.ModTime != int64(decryptedMsg.GetTime()) {
+		t.Fatalf("Expected modification time to be %d got %d", testMeta.ModTime, int64(decryptedMsg.GetTime()))
 	}
 }
 
 func TestKeyRing_DecryptSplitStreamCompatible(t *testing.T) {
 	messageBytes := []byte("Hello World!")
-	modTime := GetUnixTime()
 	pgpMessage, err := keyRingTestPublic.Encrypt(
-		NewPlainMessageFromFile(messageBytes, testFilename, uint32(modTime)),
+		&PlainMessage{
+			Data:     messageBytes,
+			TextType: !testMeta.IsBinary,
+			Time:     uint32(testMeta.ModTime),
+			Filename: testMeta.Filename,
+		},
 		keyRingTestPrivate,
 	)
 	if err != nil {
@@ -380,14 +362,9 @@ func TestKeyRing_DecryptSplitStreamCompatible(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while verifying the signature, got:", err)
 	}
-	if !decryptedReader.IsBinary() {
-		t.Fatalf("Expected isBinary to be %t got %t", true, decryptedReader.IsBinary())
-	}
-	if testFilename != decryptedReader.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
-	}
-	if modTime != decryptedReader.GetModificationTime() {
-		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	decryptedMeta := decryptedReader.GetMetadata()
+	if !reflect.DeepEqual(testMeta, decryptedMeta) {
+		t.Fatalf("Expected the decrypted metadata to be %v got %v", testMeta, decryptedMeta)
 	}
 }
 

--- a/crypto/keyring_streaming_test.go
+++ b/crypto/keyring_streaming_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const testFilename = "filename.txt"
+
 func TestKeyRing_EncryptStream(t *testing.T) {
 	keyRingPrivate, err := keyRingTestPrivate.Copy()
 	if err != nil {

--- a/crypto/keyring_streaming_test.go
+++ b/crypto/keyring_streaming_test.go
@@ -23,12 +23,11 @@ func TestKeyRing_EncryptStream(t *testing.T) {
 	messageReader := bytes.NewReader(messageBytes)
 	var ciphertextBuf bytes.Buffer
 	isBinary := true
-	filename := "filename.txt"
 	modTime := GetUnixTime()
 	messageWriter, err := keyRingPublic.EncryptStream(
 		&ciphertextBuf,
 		isBinary,
-		filename,
+		testFilename,
 		modTime,
 		keyRingPrivate,
 	)
@@ -82,8 +81,8 @@ func TestKeyRing_EncryptStream(t *testing.T) {
 	if isBinary != decryptedReader.IsBinary() {
 		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
 	}
-	if filename != decryptedReader.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", filename, decryptedReader.GetFilename())
+	if testFilename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
 	}
 	if modTime != decryptedReader.GetModificationTime() {
 		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
@@ -103,12 +102,11 @@ func TestKeyRing_EncryptSplitStream(t *testing.T) {
 	messageReader := bytes.NewReader(messageBytes)
 	var dataPacketBuf bytes.Buffer
 	isBinary := true
-	filename := "filename.txt"
 	modTime := GetUnixTime()
 	encryptionResult, err := keyRingPublic.EncryptSplitStream(
 		&dataPacketBuf,
 		isBinary,
-		filename,
+		testFilename,
 		modTime,
 		keyRingPrivate,
 	)
@@ -169,8 +167,8 @@ func TestKeyRing_EncryptSplitStream(t *testing.T) {
 	if isBinary != decryptedReader.IsBinary() {
 		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
 	}
-	if filename != decryptedReader.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", filename, decryptedReader.GetFilename())
+	if testFilename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
 	}
 	if modTime != decryptedReader.GetModificationTime() {
 		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())

--- a/crypto/keyring_streaming_test.go
+++ b/crypto/keyring_streaming_test.go
@@ -103,7 +103,6 @@ func TestKeyRing_EncryptDecryptStream(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected an error while verifying the signature with no keyring, got nil")
 	}
-
 }
 
 func TestKeyRing_EncryptStreamCompatible(t *testing.T) {

--- a/crypto/keyring_streaming_test.go
+++ b/crypto/keyring_streaming_test.go
@@ -31,7 +31,7 @@ func TestKeyRing_EncryptStream(t *testing.T) {
 		keyRingPrivate,
 	)
 	if err != nil {
-		t.Fatal("Expected no error while calling EncryptStream, got:", err)
+		t.Fatal("Expected no error while encrypting stream with key ring, got:", err)
 	}
 	reachedEnd := false
 	bufferSize := 2
@@ -64,7 +64,7 @@ func TestKeyRing_EncryptStream(t *testing.T) {
 		GetUnixTime(),
 	)
 	if err != nil {
-		t.Fatal("Expected no error while calling DecryptStream, got:", err)
+		t.Fatal("Expected no error while calling decrypting stream with key ring, got:", err)
 	}
 	decryptedBytes, err := io.ReadAll(decryptedReader)
 	if err != nil {
@@ -111,7 +111,7 @@ func TestKeyRing_EncryptSplitStream(t *testing.T) {
 		keyRingPrivate,
 	)
 	if err != nil {
-		t.Fatal("Expected no error while calling EncryptStream, got:", err)
+		t.Fatal("Expected no error while calling encrypting split stream with key ring, got:", err)
 	}
 	messageWriter := encryptionResult
 	reachedEnd := false
@@ -144,15 +144,6 @@ func TestKeyRing_EncryptSplitStream(t *testing.T) {
 		t.Fatal("Expected no error while accessing key packet, got:", err)
 	}
 	dataPacket := dataPacketBuf.Bytes()
-	pgpSplit := PGPSplitMessage{keyPacket, dataPacket}
-	plainMessage, err := keyRingPrivate.Decrypt(pgpSplit.GetPGPMessage(), nil, 0)
-	if err != nil {
-		t.Fatal("Expected no error while decrypting normally, got:", err)
-	}
-	decryptedBytes := plainMessage.Data
-	if !bytes.Equal(decryptedBytes, messageBytes) {
-		t.Fatalf("Expected the normally decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
-	}
 	decryptedReader, err := keyRingPrivate.DecryptSplitStream(
 		keyPacket,
 		bytes.NewReader(dataPacket),
@@ -160,9 +151,9 @@ func TestKeyRing_EncryptSplitStream(t *testing.T) {
 		GetUnixTime(),
 	)
 	if err != nil {
-		t.Fatal("Expected no error while calling DecryptStream, got:", err)
+		t.Fatal("Expected no error while decrypting split stream with key ring, got:", err)
 	}
-	decryptedBytes, err = io.ReadAll(decryptedReader)
+	decryptedBytes, err := io.ReadAll(decryptedReader)
 	if err != nil {
 		t.Fatal("Expected no error while reading the decrypted data, got:", err)
 	}

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -188,11 +188,10 @@ func encryptWithSessionKey(message *PlainMessage, sk *SessionKey, signEntity *op
 	if signWriter != nil {
 		_, err = signWriter.Write(message.GetBinary())
 		if err != nil {
-			return nil, errors.Wrap(err, "gopenpgp: error in writing data to sign and encrypt")
+			return nil, errors.Wrap(err, "gopenpgp: error in writing signed message")
 		}
 		err = signWriter.Close()
 		if err != nil {
-			// Do we still need to close encryptWriter ?
 			return nil, errors.Wrap(err, "gopenpgp: error in closing signing writer")
 		}
 	} else {

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -187,6 +187,9 @@ func encryptWithSessionKey(message *PlainMessage, sk *SessionKey, signEntity *op
 	}
 	if signWriter != nil {
 		_, err = signWriter.Write(message.GetBinary())
+		if err != nil {
+			return nil, errors.Wrap(err, "gopenpgp: error in writing data to sign and encrypt")
+		}
 		err = signWriter.Close()
 		if err != nil {
 			// Do we still need to close encryptWriter ?
@@ -266,7 +269,7 @@ func (sk *SessionKey) Decrypt(dataPacket []byte) (*PlainMessage, error) {
 func (sk *SessionKey) DecryptAndVerify(dataPacket []byte, verifyKeyRing *KeyRing, verifyTime int64) (*PlainMessage, error) {
 	var messageReader = bytes.NewReader(dataPacket)
 
-	md, err := decryptStreamWithSessionKey(sk, messageReader, verifyKeyRing, verifyTime)
+	md, err := decryptStreamWithSessionKey(sk, messageReader, verifyKeyRing)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +292,7 @@ func (sk *SessionKey) DecryptAndVerify(dataPacket []byte, verifyKeyRing *KeyRing
 	}, err
 }
 
-func decryptStreamWithSessionKey(sk *SessionKey, messageReader io.Reader, verifyKeyRing *KeyRing, verifyTime int64) (*openpgp.MessageDetails, error) {
+func decryptStreamWithSessionKey(sk *SessionKey, messageReader io.Reader, verifyKeyRing *KeyRing) (*openpgp.MessageDetails, error) {
 	var decrypted io.ReadCloser
 	var keyring openpgp.EntityList
 

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -228,7 +228,7 @@ func encryptStreamWithSessionKey(
 		}
 	}
 
-	if signEntity != nil { // nolint:nestif
+	if signEntity != nil {
 		hints := &openpgp.FileHints{
 			IsBinary: isBinary,
 			FileName: filename,

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -185,7 +185,7 @@ func encryptWithSessionKey(message *PlainMessage, sk *SessionKey, signEntity *op
 	if err != nil {
 		return nil, err
 	}
-	if signWriter != nil {
+	if signEntity != nil {
 		_, err = signWriter.Write(message.GetBinary())
 		if err != nil {
 			return nil, errors.Wrap(err, "gopenpgp: error in writing signed message")
@@ -335,7 +335,7 @@ func decryptStreamWithSessionKey(sk *SessionKey, messageReader io.Reader, verify
 		return nil, errors.Wrap(err, "gopenpgp: unable to decode symmetric packet")
 	}
 
-	return md, err
+	return md, nil
 }
 
 func (sk *SessionKey) checkSize() error {

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/pkg/errors"
@@ -171,65 +172,83 @@ func (sk *SessionKey) EncryptWithCompression(message *PlainMessage) ([]byte, err
 
 func encryptWithSessionKey(message *PlainMessage, sk *SessionKey, signEntity *openpgp.Entity, config *packet.Config) ([]byte, error) {
 	var encBuf = new(bytes.Buffer)
-	var encryptWriter, signWriter io.WriteCloser
 
-	encryptWriter, err := packet.SerializeSymmetricallyEncrypted(encBuf, config.Cipher(), sk.Key, config)
+	encryptWriter, signWriter, err := encryptStreamWithSessionKey(
+		message.IsBinary(),
+		message.Filename,
+		message.Time,
+		encBuf,
+		sk,
+		signEntity,
+		config,
+	)
 	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: unable to encrypt")
+		return nil, err
+	}
+	if signWriter != nil {
+		_, err = signWriter.Write(message.GetBinary())
+		err = signWriter.Close()
+		if err != nil {
+			// Do we still need to close encryptWriter ?
+			return nil, errors.Wrap(err, "gopenpgp: error in closing signing writer")
+		}
+	} else {
+		_, err = encryptWriter.Write(message.GetBinary())
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: error in writing message")
+	}
+	err = encryptWriter.Close()
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: error in closing encryption writer")
+	}
+	return encBuf.Bytes(), nil
+}
+
+func encryptStreamWithSessionKey(
+	isBinary bool,
+	filename string,
+	modTime uint32,
+	dataPacketWriter io.Writer,
+	sk *SessionKey,
+	signEntity *openpgp.Entity,
+	config *packet.Config,
+) (encryptWriter, signWriter io.WriteCloser, err error) {
+	encryptWriter, err = packet.SerializeSymmetricallyEncrypted(dataPacketWriter, config.Cipher(), sk.Key, config)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "gopenpgp: unable to encrypt")
 	}
 
 	if algo := config.Compression(); algo != packet.CompressionNone {
 		encryptWriter, err = packet.SerializeCompressed(encryptWriter, algo, config.CompressionConfig)
 		if err != nil {
-			return nil, errors.Wrap(err, "gopenpgp: error in compression")
+			return nil, nil, errors.Wrap(err, "gopenpgp: error in compression")
 		}
 	}
 
 	if signEntity != nil { // nolint:nestif
 		hints := &openpgp.FileHints{
-			IsBinary: message.IsBinary(),
-			FileName: message.Filename,
-			ModTime:  message.getFormattedTime(),
+			IsBinary: isBinary,
+			FileName: filename,
+			ModTime:  time.Unix(int64(modTime), 0),
 		}
 
 		signWriter, err = openpgp.Sign(encryptWriter, signEntity, hints, config)
 		if err != nil {
-			return nil, errors.Wrap(err, "gopenpgp: unable to sign")
-		}
-
-		_, err = signWriter.Write(message.GetBinary())
-		if err != nil {
-			return nil, errors.Wrap(err, "gopenpgp: error in writing signed message")
-		}
-
-		err = signWriter.Close()
-		if err != nil {
-			return nil, errors.Wrap(err, "gopenpgp: error in closing signing writer")
+			return nil, nil, errors.Wrap(err, "gopenpgp: unable to sign")
 		}
 	} else {
 		encryptWriter, err = packet.SerializeLiteral(
 			encryptWriter,
-			message.IsBinary(),
-			message.Filename,
-			message.Time,
+			isBinary,
+			filename,
+			modTime,
 		)
-
 		if err != nil {
-			return nil, errors.Wrap(err, "gopenpgp: unable to serialize")
-		}
-
-		_, err = encryptWriter.Write(message.GetBinary())
-		if err != nil {
-			return nil, errors.Wrap(err, "gopenpgp: error in writing message")
+			return nil, nil, errors.Wrap(err, "gopenpgp: unable to serialize")
 		}
 	}
-
-	err = encryptWriter.Close()
-	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: error in closing encryption writer")
-	}
-
-	return encBuf.Bytes(), nil
+	return encryptWriter, signWriter, nil
 }
 
 // Decrypt decrypts pgp data packets using directly a session key.
@@ -246,8 +265,32 @@ func (sk *SessionKey) Decrypt(dataPacket []byte) (*PlainMessage, error) {
 // * output: PlainMessage.
 func (sk *SessionKey) DecryptAndVerify(dataPacket []byte, verifyKeyRing *KeyRing, verifyTime int64) (*PlainMessage, error) {
 	var messageReader = bytes.NewReader(dataPacket)
+
+	md, err := decryptStreamWithSessionKey(sk, messageReader, verifyKeyRing, verifyTime)
+	if err != nil {
+		return nil, err
+	}
+	messageBuf := new(bytes.Buffer)
+	_, err = messageBuf.ReadFrom(md.UnverifiedBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: error in reading message body")
+	}
+
+	if verifyKeyRing != nil {
+		processSignatureExpiration(md, verifyTime)
+		err = verifyDetailsSignature(md, verifyKeyRing)
+	}
+
+	return &PlainMessage{
+		Data:     messageBuf.Bytes(),
+		TextType: !md.LiteralData.IsBinary,
+		Filename: md.LiteralData.FileName,
+		Time:     md.LiteralData.Time,
+	}, err
+}
+
+func decryptStreamWithSessionKey(sk *SessionKey, messageReader io.Reader, verifyKeyRing *KeyRing, verifyTime int64) (*openpgp.MessageDetails, error) {
 	var decrypted io.ReadCloser
-	var decBuf bytes.Buffer
 	var keyring openpgp.EntityList
 
 	// Read symmetrically encrypted data packet
@@ -273,45 +316,24 @@ func (sk *SessionKey) DecryptAndVerify(dataPacket []byte, verifyKeyRing *KeyRing
 	default:
 		return nil, errors.New("gopenpgp: invalid packet type")
 	}
-	_, err = decBuf.ReadFrom(decrypted)
-	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: unable to read from decrypted symmetric packet")
-	}
 
 	config := &packet.Config{
 		Time: getTimeGenerator(),
 	}
 
 	// Push decrypted packet as literal packet and use openpgp's reader
-
 	if verifyKeyRing != nil {
 		keyring = verifyKeyRing.entities
 	} else {
 		keyring = openpgp.EntityList{}
 	}
 
-	md, err := openpgp.ReadMessage(&decBuf, keyring, nil, config)
+	md, err := openpgp.ReadMessage(decrypted, keyring, nil, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: unable to decode symmetric packet")
 	}
 
-	messageBuf := new(bytes.Buffer)
-	_, err = messageBuf.ReadFrom(md.UnverifiedBody)
-	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: error in reading message body")
-	}
-
-	if verifyKeyRing != nil {
-		processSignatureExpiration(md, verifyTime)
-		err = verifyDetailsSignature(md, verifyKeyRing)
-	}
-
-	return &PlainMessage{
-		Data:     messageBuf.Bytes(),
-		TextType: !md.LiteralData.IsBinary,
-		Filename: md.LiteralData.FileName,
-		Time:     md.LiteralData.Time,
-	}, err
+	return md, err
 }
 
 func (sk *SessionKey) checkSize() error {

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -23,7 +23,7 @@ func (w *signAndEncryptWriteCloser) Close() error {
 }
 
 // EncryptStream is used to encrypt data as a Writer.
-// It takes a writer for the encrypted data packet and returns a writer for the plaintext data
+// It takes a writer for the encrypted data packet and returns a writer for the plaintext data.
 // If signKeyRing is not nil, it is used to do an embedded signature.
 func (sk *SessionKey) EncryptStream(
 	dataPacketWriter Writer,

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -77,7 +77,8 @@ func (sk *SessionKey) EncryptStream(
 // verify the embedded signature with the given key ring and verification time.
 func (sk *SessionKey) DecryptStream(
 	dataPacketReader Reader,
-	verifyKeyRing *KeyRing, verifyTime int64,
+	verifyKeyRing *KeyRing,
+	verifyTime int64,
 ) (plainMessage *PlainMessageReader, err error) {
 	messageDetails, err := decryptStreamWithSessionKey(
 		sk,

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -48,7 +48,12 @@ func (sk *SessionKey) EncryptStream(
 	}
 
 	if plainMessageMetadata == nil {
-		plainMessageMetadata = &PlainMessageMetadata{}
+		// Use sensible default metadata
+		plainMessageMetadata = &PlainMessageMetadata{
+			IsBinary: true,
+			Filename: "",
+			ModTime:  GetUnixTime(),
+		}
 	}
 
 	encryptWriter, signWriter, err := encryptStreamWithSessionKey(

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -1,22 +1,20 @@
 package crypto
 
 import (
-	"io"
-
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/pkg/errors"
 )
 
-type signAndEncryptWriteCloser struct {
-	signWriter    io.WriteCloser
-	encryptWriter io.WriteCloser
+type SignAndEncryptWriteCloser struct {
+	signWriter    WriteCloser
+	encryptWriter WriteCloser
 }
 
-func (w *signAndEncryptWriteCloser) Write(b []byte) (int, error) {
+func (w *SignAndEncryptWriteCloser) Write(b []byte) (int, error) {
 	return w.signWriter.Write(b)
 }
 
-func (w *signAndEncryptWriteCloser) Close() error {
+func (w *SignAndEncryptWriteCloser) Close() error {
 	err := w.signWriter.Close()
 	if err != nil {
 		return err
@@ -28,7 +26,7 @@ func (sk *SessionKey) EncryptStream(
 	dataPacketWriter Writer,
 	isBinary bool,
 	filename string,
-	modTime uint32,
+	modTime int64,
 	signKeyRing *KeyRing,
 ) (plainMessageWriter WriteCloser, err error) {
 	dc, err := sk.GetCipherFunc()
@@ -49,7 +47,7 @@ func (sk *SessionKey) EncryptStream(
 	encryptWriter, signWriter, err := encryptStreamWithSessionKey(
 		isBinary,
 		filename,
-		modTime,
+		uint32(modTime),
 		dataPacketWriter,
 		sk,
 		signEntity,
@@ -60,7 +58,7 @@ func (sk *SessionKey) EncryptStream(
 		return nil, err
 	}
 	if signWriter != nil {
-		plainMessageWriter = &signAndEncryptWriteCloser{signWriter, encryptWriter}
+		plainMessageWriter = &SignAndEncryptWriteCloser{signWriter, encryptWriter}
 	} else {
 		plainMessageWriter = encryptWriter
 	}

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -19,6 +19,7 @@ func (w *signAndEncryptWriteCloser) Close() error {
 	if err := w.signWriter.Close(); err != nil {
 		return err
 	}
+	// Do we still need to close encryptWriter ?
 	return w.encryptWriter.Close()
 }
 
@@ -83,7 +84,6 @@ func (sk *SessionKey) DecryptStream(
 		sk,
 		dataPacketReader,
 		verifyKeyRing,
-		verifyTime,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: error in reading message")

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -16,13 +16,15 @@ func (w *signAndEncryptWriteCloser) Write(b []byte) (int, error) {
 }
 
 func (w *signAndEncryptWriteCloser) Close() error {
-	err := w.signWriter.Close()
-	if err != nil {
+	if err := w.signWriter.Close(); err != nil {
 		return err
 	}
 	return w.encryptWriter.Close()
 }
 
+// EncryptStream is used to encrypt data as a Writer.
+// It takes a writer for the encrypted data packet and returns a writer for the plaintext data
+// If signKeyRing is not nil, it is used to do an embedded signature.
 func (sk *SessionKey) EncryptStream(
 	dataPacketWriter Writer,
 	isBinary bool,
@@ -68,6 +70,11 @@ func (sk *SessionKey) EncryptStream(
 	return plainMessageWriter, err
 }
 
+// DecryptStream is used to decrypt a data packet as a Reader.
+// It takes a reader for the data packet
+// and returns a PlainMessageReader for the plaintext data.
+// If verifyKeyRing is not nil, PlainMessageReader.VerifySignature() will
+// verify the embedded signature with the given key ring and verification time.
 func (sk *SessionKey) DecryptStream(
 	dataPacketReader Reader,
 	verifyKeyRing *KeyRing, verifyTime int64,

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -19,7 +19,6 @@ func (w *signAndEncryptWriteCloser) Close() error {
 	if err := w.signWriter.Close(); err != nil {
 		return err
 	}
-	// Do we still need to close encryptWriter ?
 	return w.encryptWriter.Close()
 }
 

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/pkg/errors"
 )
@@ -38,10 +39,12 @@ func (sk *SessionKey) EncryptStream(
 		Time:          getTimeGenerator(),
 		DefaultCipher: dc,
 	}
-
-	signEntity, err := signKeyRing.getSigningEntity()
-	if err != nil {
-		return nil, errors.Wrap(err, "gopenpgp: unable to sign")
+	var signEntity *openpgp.Entity
+	if signKeyRing != nil {
+		signEntity, err = signKeyRing.getSigningEntity()
+		if err != nil {
+			return nil, errors.Wrap(err, "gopenpgp: unable to sign")
+		}
 	}
 
 	encryptWriter, signWriter, err := encryptStreamWithSessionKey(

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -1,0 +1,90 @@
+package crypto
+
+import (
+	"io"
+
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/pkg/errors"
+)
+
+type signAndEncryptWriteCloser struct {
+	signWriter    io.WriteCloser
+	encryptWriter io.WriteCloser
+}
+
+func (w *signAndEncryptWriteCloser) Write(b []byte) (int, error) {
+	return w.signWriter.Write(b)
+}
+
+func (w *signAndEncryptWriteCloser) Close() error {
+	err := w.signWriter.Close()
+	if err != nil {
+		return err
+	}
+	return w.encryptWriter.Close()
+}
+
+func (sk *SessionKey) EncryptStream(
+	dataPacketWriter Writer,
+	isBinary bool,
+	filename string,
+	modTime uint32,
+	signKeyRing *KeyRing,
+) (plainMessageWriter WriteCloser, err error) {
+	dc, err := sk.GetCipherFunc()
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: unable to encrypt with session key")
+	}
+
+	config := &packet.Config{
+		Time:          getTimeGenerator(),
+		DefaultCipher: dc,
+	}
+
+	signEntity, err := signKeyRing.getSigningEntity()
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: unable to sign")
+	}
+
+	encryptWriter, signWriter, err := encryptStreamWithSessionKey(
+		isBinary,
+		filename,
+		modTime,
+		dataPacketWriter,
+		sk,
+		signEntity,
+		config,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	if signWriter != nil {
+		plainMessageWriter = &signAndEncryptWriteCloser{signWriter, encryptWriter}
+	} else {
+		plainMessageWriter = encryptWriter
+	}
+	return plainMessageWriter, err
+}
+
+func (sk *SessionKey) DecryptStream(
+	dataPacketReader Reader,
+	verifyKeyRing *KeyRing, verifyTime int64,
+) (plainMessage *PlainMessageReader, err error) {
+	messageDetails, err := decryptStreamWithSessionKey(
+		sk,
+		dataPacketReader,
+		verifyKeyRing,
+		verifyTime,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "gopenpgp: error in reading message")
+	}
+
+	return &PlainMessageReader{
+		messageDetails,
+		verifyKeyRing,
+		verifyTime,
+		false,
+	}, err
+}

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -5,16 +5,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-type SignAndEncryptWriteCloser struct {
+type signAndEncryptWriteCloser struct {
 	signWriter    WriteCloser
 	encryptWriter WriteCloser
 }
 
-func (w *SignAndEncryptWriteCloser) Write(b []byte) (int, error) {
+func (w *signAndEncryptWriteCloser) Write(b []byte) (int, error) {
 	return w.signWriter.Write(b)
 }
 
-func (w *SignAndEncryptWriteCloser) Close() error {
+func (w *signAndEncryptWriteCloser) Close() error {
 	err := w.signWriter.Close()
 	if err != nil {
 		return err
@@ -58,7 +58,7 @@ func (sk *SessionKey) EncryptStream(
 		return nil, err
 	}
 	if signWriter != nil {
-		plainMessageWriter = &SignAndEncryptWriteCloser{signWriter, encryptWriter}
+		plainMessageWriter = &signAndEncryptWriteCloser{signWriter, encryptWriter}
 	} else {
 		plainMessageWriter = encryptWriter
 	}

--- a/crypto/sessionkey_streaming.go
+++ b/crypto/sessionkey_streaming.go
@@ -27,9 +27,7 @@ func (w *signAndEncryptWriteCloser) Close() error {
 // If signKeyRing is not nil, it is used to do an embedded signature.
 func (sk *SessionKey) EncryptStream(
 	dataPacketWriter Writer,
-	isBinary bool,
-	filename string,
-	modTime int64,
+	plainMessageMetadata *PlainMessageMetadata,
 	signKeyRing *KeyRing,
 ) (plainMessageWriter WriteCloser, err error) {
 	dc, err := sk.GetCipherFunc()
@@ -49,10 +47,14 @@ func (sk *SessionKey) EncryptStream(
 		}
 	}
 
+	if plainMessageMetadata == nil {
+		plainMessageMetadata = &PlainMessageMetadata{}
+	}
+
 	encryptWriter, signWriter, err := encryptStreamWithSessionKey(
-		isBinary,
-		filename,
-		uint32(modTime),
+		plainMessageMetadata.IsBinary,
+		plainMessageMetadata.Filename,
+		uint32(plainMessageMetadata.ModTime),
 		dataPacketWriter,
 		sk,
 		signEntity,

--- a/crypto/sessionkey_streaming_test.go
+++ b/crypto/sessionkey_streaming_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestSessionKey_EncryptStream(t *testing.T) {
+func TestSessionKey_EncryptDecryptStream(t *testing.T) {
 	keyRingPrivate, err := keyRingTestPrivate.Copy()
 	if err != nil {
 		t.Fatal("Expected no error while copying keyring, got:", err)
@@ -79,6 +79,130 @@ func TestSessionKey_EncryptStream(t *testing.T) {
 	}
 	if isBinary != decryptedReader.IsBinary() {
 		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
+	}
+	if testFilename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
+	}
+	if modTime != decryptedReader.GetModificationTime() {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	}
+}
+
+func TestSessionKey_EncryptStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	var dataPacketBuf bytes.Buffer
+	isBinary := true
+	modTime := GetUnixTime()
+	messageWriter, err := testSessionKey.EncryptStream(
+		&dataPacketBuf,
+		isBinary,
+		testFilename,
+		modTime,
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while encrypting stream with session key, got:", err)
+	}
+	bufferSize := 2
+	buffer := make([]byte, bufferSize)
+	reachedEnd := false
+	for !reachedEnd {
+		n, err := messageReader.Read(buffer)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading data, got:", err)
+			}
+		}
+		writtenTotal := 0
+		for writtenTotal < n {
+			written, err := messageWriter.Write(buffer[writtenTotal:n])
+			if err != nil {
+				t.Fatal("Expected no error while writing data, got:", err)
+			}
+			writtenTotal += written
+		}
+	}
+	err = messageWriter.Close()
+	if err != nil {
+		t.Fatal("Expected no error while closing plaintext writer, got:", err)
+	}
+	dataPacket := dataPacketBuf.Bytes()
+	decryptedMsg, err := testSessionKey.DecryptAndVerify(
+		dataPacket,
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling DecryptAndVerify, got:", err)
+	}
+	decryptedBytes := decryptedMsg.Data
+	if err != nil {
+		t.Fatal("Expected no error while reading the decrypted data, got:", err)
+	}
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	if isBinary != decryptedMsg.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedMsg.IsBinary())
+	}
+	if testFilename != decryptedMsg.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedMsg.GetFilename())
+	}
+	if modTime != int64(decryptedMsg.GetTime()) {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, int64(decryptedMsg.GetTime()))
+	}
+}
+
+func TestSessionKey_DecryptStreamCompatible(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	modTime := GetUnixTime()
+	dataPacket, err := testSessionKey.EncryptAndSign(
+		NewPlainMessageFromFile(messageBytes, testFilename, uint32(modTime)),
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while encrypting plaintext, got:", err)
+	}
+	decryptedReader, err := testSessionKey.DecryptStream(
+		bytes.NewReader(dataPacket),
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling DecryptStream, got:", err)
+	}
+	decryptedBytes, err := io.ReadAll(decryptedReader)
+	if err != nil {
+		t.Fatal("Expected no error while reading the decrypted data, got:", err)
+	}
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	err = decryptedReader.VerifySignature()
+	if err != nil {
+		t.Fatal("Expected no error while verifying the signature, got:", err)
+	}
+	if !decryptedReader.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", true, decryptedReader.IsBinary())
 	}
 	if testFilename != decryptedReader.GetFilename() {
 		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())

--- a/crypto/sessionkey_streaming_test.go
+++ b/crypto/sessionkey_streaming_test.go
@@ -21,12 +21,11 @@ func TestSessionKey_EncryptStream(t *testing.T) {
 	messageReader := bytes.NewReader(messageBytes)
 	var dataPacketBuf bytes.Buffer
 	isBinary := true
-	filename := "filename.txt"
 	modTime := GetUnixTime()
 	messageWriter, err := testSessionKey.EncryptStream(
 		&dataPacketBuf,
 		isBinary,
-		filename,
+		testFilename,
 		modTime,
 		keyRingPrivate,
 	)
@@ -81,8 +80,8 @@ func TestSessionKey_EncryptStream(t *testing.T) {
 	if isBinary != decryptedReader.IsBinary() {
 		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
 	}
-	if filename != decryptedReader.GetFilename() {
-		t.Fatalf("Expected filename to be %s got %s", filename, decryptedReader.GetFilename())
+	if testFilename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", testFilename, decryptedReader.GetFilename())
 	}
 	if modTime != decryptedReader.GetModificationTime() {
 		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())

--- a/crypto/sessionkey_streaming_test.go
+++ b/crypto/sessionkey_streaming_test.go
@@ -1,0 +1,90 @@
+package crypto
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestSessionKey_EncryptStream(t *testing.T) {
+	keyRingPrivate, err := keyRingTestPrivate.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	keyRingPublic, err := keyRingTestPublic.Copy()
+	if err != nil {
+		t.Fatal("Expected no error while copying keyring, got:", err)
+	}
+	messageBytes := []byte("Hello World!")
+	messageReader := bytes.NewReader(messageBytes)
+	var dataPacketBuf bytes.Buffer
+	isBinary := true
+	filename := "filename.txt"
+	modTime := GetUnixTime()
+	messageWriter, err := testSessionKey.EncryptStream(
+		&dataPacketBuf,
+		isBinary,
+		filename,
+		modTime,
+		keyRingPrivate,
+	)
+	if err != nil {
+		t.Fatal("Expected no error while encrypting stream with session key, got:", err)
+	}
+	bufferSize := 2
+	buffer := make([]byte, bufferSize)
+	reachedEnd := false
+	for !reachedEnd {
+		n, err := messageReader.Read(buffer)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading data, got:", err)
+			}
+		}
+		writtenTotal := 0
+		for writtenTotal < n {
+			written, err := messageWriter.Write(buffer[writtenTotal:n])
+			if err != nil {
+				t.Fatal("Expected no error while writing data, got:", err)
+			}
+			writtenTotal += written
+		}
+	}
+	err = messageWriter.Close()
+	if err != nil {
+		t.Fatal("Expected no error while closing plaintext writer, got:", err)
+	}
+	dataPacket := dataPacketBuf.Bytes()
+	decryptedReader, err := testSessionKey.DecryptStream(
+		bytes.NewReader(dataPacket),
+		keyRingPublic,
+		GetUnixTime(),
+	)
+	if err != nil {
+		t.Fatal("Expected no error while calling DecryptStream, got:", err)
+	}
+	decryptedBytes, err := io.ReadAll(decryptedReader)
+	if err != nil {
+		t.Fatal("Expected no error while reading the decrypted data, got:", err)
+	}
+	if !bytes.Equal(decryptedBytes, messageBytes) {
+		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
+	}
+	err = decryptedReader.VerifySignature()
+	if err != nil {
+		t.Fatal("Expected no error while verifying the signature, got:", err)
+	}
+	if isBinary != decryptedReader.IsBinary() {
+		t.Fatalf("Expected isBinary to be %t got %t", isBinary, decryptedReader.IsBinary())
+	}
+	if filename != decryptedReader.GetFilename() {
+		t.Fatalf("Expected filename to be %s got %s", filename, decryptedReader.GetFilename())
+	}
+	if modTime != decryptedReader.GetModificationTime() {
+		t.Fatalf("Expected modification time to be %d got %d", modTime, decryptedReader.GetModificationTime())
+	}
+}

--- a/crypto/sessionkey_streaming_test.go
+++ b/crypto/sessionkey_streaming_test.go
@@ -9,14 +9,6 @@ import (
 )
 
 func TestSessionKey_EncryptDecryptStream(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var dataPacketBuf bytes.Buffer
@@ -27,7 +19,7 @@ func TestSessionKey_EncryptDecryptStream(t *testing.T) {
 		isBinary,
 		testFilename,
 		modTime,
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while encrypting stream with session key, got:", err)
@@ -60,7 +52,7 @@ func TestSessionKey_EncryptDecryptStream(t *testing.T) {
 	dataPacket := dataPacketBuf.Bytes()
 	decryptedReader, err := testSessionKey.DecryptStream(
 		bytes.NewReader(dataPacket),
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {
@@ -89,14 +81,6 @@ func TestSessionKey_EncryptDecryptStream(t *testing.T) {
 }
 
 func TestSessionKey_EncryptStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	messageReader := bytes.NewReader(messageBytes)
 	var dataPacketBuf bytes.Buffer
@@ -107,7 +91,7 @@ func TestSessionKey_EncryptStreamCompatible(t *testing.T) {
 		isBinary,
 		testFilename,
 		modTime,
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while encrypting stream with session key, got:", err)
@@ -140,7 +124,7 @@ func TestSessionKey_EncryptStreamCompatible(t *testing.T) {
 	dataPacket := dataPacketBuf.Bytes()
 	decryptedMsg, err := testSessionKey.DecryptAndVerify(
 		dataPacket,
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {
@@ -165,26 +149,18 @@ func TestSessionKey_EncryptStreamCompatible(t *testing.T) {
 }
 
 func TestSessionKey_DecryptStreamCompatible(t *testing.T) {
-	keyRingPrivate, err := keyRingTestPrivate.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
-	keyRingPublic, err := keyRingTestPublic.Copy()
-	if err != nil {
-		t.Fatal("Expected no error while copying keyring, got:", err)
-	}
 	messageBytes := []byte("Hello World!")
 	modTime := GetUnixTime()
 	dataPacket, err := testSessionKey.EncryptAndSign(
 		NewPlainMessageFromFile(messageBytes, testFilename, uint32(modTime)),
-		keyRingPrivate,
+		keyRingTestPrivate,
 	)
 	if err != nil {
 		t.Fatal("Expected no error while encrypting plaintext, got:", err)
 	}
 	decryptedReader, err := testSessionKey.DecryptStream(
 		bytes.NewReader(dataPacket),
-		keyRingPublic,
+		keyRingTestPublic,
 		GetUnixTime(),
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ProtonMail/gopenpgp/v2
 go 1.15
 
 require (
-	github.com/ProtonMail/go-crypto v0.0.0-20210503074116-6a33223a51e6
+	github.com/ProtonMail/go-crypto v0.0.0-20210512092938-c05353c2d58c
 	github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ProtonMail/gopenpgp/v2
 go 1.15
 
 require (
-	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
+	github.com/ProtonMail/go-crypto v0.0.0-20210503074116-6a33223a51e6
 	github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 h1:1BDTz0u9nC3//pOC
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
+github.com/ProtonMail/go-crypto v0.0.0-20210503074116-6a33223a51e6 h1:GAvhO5jJ2YkkyKuCWa2VKuHHpyZZjKgkcPvj913Mt40=
+github.com/ProtonMail/go-crypto v0.0.0-20210503074116-6a33223a51e6/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a h1:W6RrgN/sTxg1msqzFFb+G80MFmpjMw61IU+slm+wln4=
 github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a/go.mod h1:NYt+V3/4rEeDuaev/zw1zCq8uqVEuPHzDPo3OZrlGJ4=
 github.com/ProtonMail/go-mobile v0.0.0-20210326110230-f181c70e4e2b h1:XVeh08xp93T+xK6rzpCSQTZ+LwEo+ASHvOifrQ5ZgEE=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20210503074116-6a33223a51e6 h1:GAvhO5jJ2YkkyKuCWa2VKuHHpyZZjKgkcPvj913Mt40=
 github.com/ProtonMail/go-crypto v0.0.0-20210503074116-6a33223a51e6/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
+github.com/ProtonMail/go-crypto v0.0.0-20210512092938-c05353c2d58c h1:bNpaLLv2Y4kslsdkdCwAYu8Bak1aGVtxwi8Z/wy4Yuo=
+github.com/ProtonMail/go-crypto v0.0.0-20210512092938-c05353c2d58c/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a h1:W6RrgN/sTxg1msqzFFb+G80MFmpjMw61IU+slm+wln4=
 github.com/ProtonMail/go-mime v0.0.0-20190923161245-9b5a4261663a/go.mod h1:NYt+V3/4rEeDuaev/zw1zCq8uqVEuPHzDPo3OZrlGJ4=
 github.com/ProtonMail/go-mobile v0.0.0-20210326110230-f181c70e4e2b h1:XVeh08xp93T+xK6rzpCSQTZ+LwEo+ASHvOifrQ5ZgEE=

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -1,0 +1,94 @@
+// +build mobile
+
+package helper
+
+import (
+	"errors"
+	"fmt"
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+	"io"
+)
+
+type MobileReadResult struct {
+	N     int
+	IsEOF bool
+	Data  []byte
+}
+
+func NewMobileReadResult(n int, eof bool, data []byte) *MobileReadResult {
+	return &MobileReadResult{n, eof, data}
+}
+
+type MobileReader interface {
+	Read(int) (*MobileReadResult, error)
+}
+
+type Mobile2GoWriter struct {
+	writer crypto.Writer
+}
+
+func NewMobile2GoWriter(writer crypto.Writer) *Mobile2GoWriter {
+	return &Mobile2GoWriter{writer}
+}
+
+func (d *Mobile2GoWriter) Write(b []byte) (int, error) {
+	bufferCopy := make([]byte, len(b))
+	copy(bufferCopy, b)
+	return d.writer.Write(bufferCopy)
+}
+
+type Mobile2GoReader struct {
+	reader MobileReader
+}
+
+func NewMobile2GoReader(reader MobileReader) *Mobile2GoReader {
+	return &Mobile2GoReader{reader}
+}
+
+func (d *Mobile2GoReader) Read(b []byte) (int, error) {
+	result, err := d.reader.Read(len(b))
+	if err != nil {
+		fmt.Printf("error while reading %v\n", err)
+		return 0, err
+	}
+	n := result.N
+	fmt.Printf("Read %d\n", n)
+	if n > 0 {
+		copy(b, result.Data[:n])
+		fmt.Printf("Bytes %x\n", b[:n])
+	}
+	if result.IsEOF {
+		fmt.Println("EOF")
+		err = io.EOF
+	}
+	return n, err
+}
+
+type Go2MobileReader struct {
+	reader crypto.Reader
+}
+
+func NewGo2MobileReader(reader crypto.Reader) *Go2MobileReader {
+	return &Go2MobileReader{reader}
+}
+
+func (d *Go2MobileReader) Read(max int) (*MobileReadResult, error) {
+	b := make([]byte, max)
+	n, err := d.reader.Read(b)
+	result := &MobileReadResult{}
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			fmt.Println("EOF")
+			result.IsEOF = true
+		} else {
+			return nil, err
+		}
+	}
+	result.N = n
+	fmt.Printf("Read %d\n", n)
+	if n > 0 {
+		result.Data = b[:n]
+		fmt.Printf("Bytes %x\n", b[:n])
+	}
+	return result, nil
+}

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 )
@@ -38,6 +39,7 @@ func NewMobile2GoWriter(writer crypto.Writer) *Mobile2GoWriter {
 }
 
 func (d *Mobile2GoWriter) Write(b []byte) (n int, err error) {
+	defer runtime.GC()
 	bufferCopy := clone(b)
 	return d.writer.Write(bufferCopy)
 }
@@ -53,6 +55,7 @@ func NewMobile2GoReader(reader MobileReader) *Mobile2GoReader {
 }
 
 func (d *Mobile2GoReader) Read(b []byte) (n int, err error) {
+	defer runtime.GC()
 	result, err := d.reader.Read(len(b))
 	if err != nil {
 		fmt.Printf("error while reading %v\n", err)
@@ -82,6 +85,7 @@ func NewGo2MobileReader(reader crypto.Reader) *Go2MobileReader {
 }
 
 func (d *Go2MobileReader) Read(max int) (result *MobileReadResult, err error) {
+	defer runtime.GC()
 	b := make([]byte, max)
 	n, err := d.reader.Read(b)
 	result = &MobileReadResult{}

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"hash"
 	"io"
-	"runtime"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/pkg/errors"
@@ -24,7 +23,6 @@ func NewMobile2GoWriter(writer crypto.Writer) *Mobile2GoWriter {
 // Write writes the data in the provided buffer in the wrapped writer.
 // It clones the provided data to prevent errors with garbage collectors.
 func (w *Mobile2GoWriter) Write(b []byte) (n int, err error) {
-	defer runtime.GC()
 	bufferCopy := clone(b)
 	return w.writer.Write(bufferCopy)
 }
@@ -47,7 +45,6 @@ func NewMobile2GoWriterWithSHA256(writer crypto.Writer) *Mobile2GoWriterWithSHA2
 // It clones the provided data to prevent errors with garbage collectors.
 // It also computes the SHA256 hash of the data being written on the fly.
 func (w *Mobile2GoWriterWithSHA256) Write(b []byte) (n int, err error) {
-	defer runtime.GC()
 	bufferCopy := clone(b)
 	n, err = w.writer.Write(bufferCopy)
 	if err == nil {
@@ -109,7 +106,6 @@ func NewMobile2GoReader(reader MobileReader) *Mobile2GoReader {
 // Read reads data from the wrapped MobileReader and copies the read data in the provided buffer.
 // It also handles the conversion of EOF to an error.
 func (r *Mobile2GoReader) Read(b []byte) (n int, err error) {
-	defer runtime.GC()
 	result, err := r.reader.Read(len(b))
 	if err != nil {
 		return 0, errors.Wrap(err, "gopenpgp: couldn't read from mobile reader")

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -1,9 +1,7 @@
 package helper
 
 import (
-	"crypto/sha256"
 	"errors"
-	"fmt"
 	"io"
 	"runtime"
 
@@ -45,32 +43,24 @@ func (d *Mobile2GoWriter) Write(b []byte) (n int, err error) {
 }
 
 type Mobile2GoReader struct {
-	reader  MobileReader
-	debug   []byte
-	counter int
+	reader MobileReader
 }
 
 func NewMobile2GoReader(reader MobileReader) *Mobile2GoReader {
-	return &Mobile2GoReader{reader, nil, 0}
+	return &Mobile2GoReader{reader}
 }
 
 func (d *Mobile2GoReader) Read(b []byte) (n int, err error) {
 	defer runtime.GC()
 	result, err := d.reader.Read(len(b))
 	if err != nil {
-		fmt.Printf("error while reading %v\n", err)
 		return 0, err
 	}
 	n = result.N
-	d.counter++
 	if n > 0 {
 		copy(b, result.Data[:n])
-		fmt.Printf("Read %d\n", n)
-		d.debug = append(d.debug, b[:n]...)
-		fmt.Printf("%d hash %x bytes %x\n", d.counter, sha256.Sum256(d.debug), b[:n])
 	}
 	if result.IsEOF {
-		fmt.Println("EOF")
 		err = io.EOF
 	}
 	return n, err

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -38,8 +38,7 @@ func NewMobile2GoWriter(writer crypto.Writer) *Mobile2GoWriter {
 }
 
 func (d *Mobile2GoWriter) Write(b []byte) (n int, err error) {
-	bufferCopy := make([]byte, len(b))
-	copy(bufferCopy, b)
+	bufferCopy := clone(b)
 	return d.writer.Write(bufferCopy)
 }
 

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -11,26 +11,6 @@ import (
 	errorsWrap "github.com/pkg/errors"
 )
 
-type MobileReadResult struct {
-	N     int
-	IsEOF bool
-	Data  []byte
-}
-
-func NewMobileReadResult(n int, eof bool, data []byte) *MobileReadResult {
-	return &MobileReadResult{n, eof, clone(data)}
-}
-
-func clone(src []byte) (dst []byte) {
-	dst = make([]byte, len(src))
-	copy(dst, src)
-	return
-}
-
-type MobileReader interface {
-	Read(max int) (result *MobileReadResult, err error)
-}
-
 type Mobile2GoWriter struct {
 	writer crypto.Writer
 }
@@ -73,6 +53,26 @@ func (d *Mobile2GoWriterWithSHA256) Write(b []byte) (n int, err error) {
 
 func (d *Mobile2GoWriterWithSHA256) GetSHA256() []byte {
 	return d.sha256.Sum(nil)
+}
+
+type MobileReader interface {
+	Read(max int) (result *MobileReadResult, err error)
+}
+
+type MobileReadResult struct {
+	N     int
+	IsEOF bool
+	Data  []byte
+}
+
+func NewMobileReadResult(n int, eof bool, data []byte) *MobileReadResult {
+	return &MobileReadResult{n, eof, clone(data)}
+}
+
+func clone(src []byte) (dst []byte) {
+	dst = make([]byte, len(src))
+	copy(dst, src)
+	return
 }
 
 type Mobile2GoReader struct {

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -2,13 +2,12 @@ package helper
 
 import (
 	"crypto/sha256"
-	"errors"
 	"hash"
 	"io"
 	"runtime"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
-	errorsWrap "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 // Mobile2GoWriter is used to wrap a writer in the mobile app runtime,
@@ -56,7 +55,7 @@ func (w *Mobile2GoWriterWithSHA256) Write(b []byte) (n int, err error) {
 		for hashedTotal < n {
 			hashed, err := w.sha256.Write(bufferCopy[hashedTotal:n])
 			if err != nil {
-				return 0, errorsWrap.Wrap(err, "gopenpgp: couldn't hash encrypted data")
+				return 0, errors.Wrap(err, "gopenpgp: couldn't hash encrypted data")
 			}
 			hashedTotal += hashed
 		}
@@ -113,7 +112,7 @@ func (r *Mobile2GoReader) Read(b []byte) (n int, err error) {
 	defer runtime.GC()
 	result, err := r.reader.Read(len(b))
 	if err != nil {
-		return 0, errorsWrap.Wrap(err, "gopenpgp: couldn't read from mobile reader")
+		return 0, errors.Wrap(err, "gopenpgp: couldn't read from mobile reader")
 	}
 	n = result.N
 	if n > 0 {

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -26,7 +26,7 @@ func clone(src []byte) (dst []byte) {
 }
 
 type MobileReader interface {
-	Read(int) (*MobileReadResult, error)
+	Read(max int) (result *MobileReadResult, err error)
 }
 
 type Mobile2GoWriter struct {
@@ -37,7 +37,7 @@ func NewMobile2GoWriter(writer crypto.Writer) *Mobile2GoWriter {
 	return &Mobile2GoWriter{writer}
 }
 
-func (d *Mobile2GoWriter) Write(b []byte) (int, error) {
+func (d *Mobile2GoWriter) Write(b []byte) (n int, err error) {
 	bufferCopy := make([]byte, len(b))
 	copy(bufferCopy, b)
 	return d.writer.Write(bufferCopy)
@@ -53,13 +53,13 @@ func NewMobile2GoReader(reader MobileReader) *Mobile2GoReader {
 	return &Mobile2GoReader{reader, nil, 0}
 }
 
-func (d *Mobile2GoReader) Read(b []byte) (int, error) {
+func (d *Mobile2GoReader) Read(b []byte) (n int, err error) {
 	result, err := d.reader.Read(len(b))
 	if err != nil {
 		fmt.Printf("error while reading %v\n", err)
 		return 0, err
 	}
-	n := result.N
+	n = result.N
 	d.counter++
 	if n > 0 {
 		copy(b, result.Data[:n])
@@ -82,10 +82,10 @@ func NewGo2MobileReader(reader crypto.Reader) *Go2MobileReader {
 	return &Go2MobileReader{reader}
 }
 
-func (d *Go2MobileReader) Read(max int) (*MobileReadResult, error) {
+func (d *Go2MobileReader) Read(max int) (result *MobileReadResult, err error) {
 	b := make([]byte, max)
 	n, err := d.reader.Read(b)
-	result := &MobileReadResult{}
+	result = &MobileReadResult{}
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			result.IsEOF = true

--- a/helper/mobile_stream_test.go
+++ b/helper/mobile_stream_test.go
@@ -86,9 +86,9 @@ func TestMobile2GoWriterWithSHA256(t *testing.T) {
 	}
 }
 
-func TestGo2MobileReader(t *testing.T) {
+func TestGo2AndroidReader(t *testing.T) {
 	testData := []byte("Hello World!")
-	reader := NewGo2MobileReader(bytes.NewReader(testData))
+	reader := NewGo2AndroidReader(bytes.NewReader(testData))
 	var readData []byte
 	bufSize := 2
 	buffer := make([]byte, bufSize)
@@ -101,6 +101,28 @@ func TestGo2MobileReader(t *testing.T) {
 		reachedEnd = n < 0
 		if n > 0 {
 			readData = append(readData, buffer[:n]...)
+		}
+	}
+	if !bytes.Equal(testData, readData) {
+		t.Fatalf("expected data to be %x, got %x", testData, readData)
+	}
+}
+
+func TestGo2IOSReader(t *testing.T) {
+	testData := []byte("Hello World!")
+	reader := NewGo2IOSReader(bytes.NewReader(testData))
+	var readData []byte
+	bufSize := 2
+	reachedEnd := false
+	for !reachedEnd {
+		res, err := reader.Read(bufSize)
+		if err != nil {
+			t.Fatal("Expected no error while reading, got:", err)
+		}
+		n := res.N
+		reachedEnd = res.IsEOF
+		if n > 0 {
+			readData = append(readData, res.Data[:n]...)
 		}
 	}
 	if !bytes.Equal(testData, readData) {

--- a/helper/mobile_stream_test.go
+++ b/helper/mobile_stream_test.go
@@ -8,10 +8,13 @@ import (
 	"testing"
 )
 
+func cloneTestData() (a, b []byte) {
+	a = []byte("Hello World!")
+	b = clone(a)
+	return a, b
+}
 func Test_clone(t *testing.T) {
-	a := []byte("Hello World!")
-	b := clone(a)
-	if !bytes.Equal(a, b) {
+	if a, b := cloneTestData(); !bytes.Equal(a, b) {
 		t.Fatalf("expected %x, got %x", a, b)
 	}
 }

--- a/helper/mobile_stream_test.go
+++ b/helper/mobile_stream_test.go
@@ -1,0 +1,157 @@
+package helper
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"io"
+	"testing"
+)
+
+func Test_clone(t *testing.T) {
+	a := []byte("Hello World!")
+	b := clone(a)
+	if !bytes.Equal(a, b) {
+		t.Fatalf("expected %x, got %x", a, b)
+	}
+}
+
+func TestMobile2GoWriter(t *testing.T) {
+	testData := []byte("Hello World!")
+	outBuf := &bytes.Buffer{}
+	reader := bytes.NewReader(testData)
+	writer := NewMobile2GoWriter(outBuf)
+	bufSize := 2
+	writeBuf := make([]byte, bufSize)
+	reachedEnd := false
+	for !reachedEnd {
+		n, err := reader.Read(writeBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading, got:", err)
+			}
+		}
+		writtenTotal := 0
+		for writtenTotal < n {
+			written, err := writer.Write(writeBuf[writtenTotal:n])
+			if err != nil {
+				t.Fatal("Expected no error while writing, got:", err)
+			}
+			writtenTotal += written
+		}
+	}
+	if writtenData := outBuf.Bytes(); !bytes.Equal(testData, writtenData) {
+		t.Fatalf("expected %x, got %x", testData, writtenData)
+	}
+}
+
+func TestMobile2GoWriterWithSHA256(t *testing.T) {
+	testData := []byte("Hello World!")
+	testHash := sha256.Sum256(testData)
+	outBuf := &bytes.Buffer{}
+	reader := bytes.NewReader(testData)
+	writer := NewMobile2GoWriterWithSHA256(outBuf)
+	bufSize := 2
+	writeBuf := make([]byte, bufSize)
+	reachedEnd := false
+	for !reachedEnd {
+		n, err := reader.Read(writeBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading, got:", err)
+			}
+		}
+		writtenTotal := 0
+		for writtenTotal < n {
+			written, err := writer.Write(writeBuf[writtenTotal:n])
+			if err != nil {
+				t.Fatal("Expected no error while writing, got:", err)
+			}
+			writtenTotal += written
+		}
+	}
+	if writtenData := outBuf.Bytes(); !bytes.Equal(testData, writtenData) {
+		t.Fatalf("expected data to be %x, got %x", testData, writtenData)
+	}
+
+	if writtenHash := writer.GetSHA256(); !bytes.Equal(testHash[:], writtenHash) {
+		t.Fatalf("expected has to be %x, got %x", testHash, writtenHash)
+	}
+}
+
+func TestGo2MobileReader(t *testing.T) {
+	testData := []byte("Hello World!")
+	reader := NewGo2MobileReader(bytes.NewReader(testData))
+	var readData []byte
+	bufSize := 2
+	reachedEnd := false
+	for !reachedEnd {
+		res, err := reader.Read(bufSize)
+		if err != nil {
+			t.Fatal("Expected no error while reading, got:", err)
+		}
+		n := res.N
+		reachedEnd = res.IsEOF
+		if n > 0 {
+			readData = append(readData, res.Data[:n]...)
+		}
+	}
+	if !bytes.Equal(testData, readData) {
+		t.Fatalf("expected data to be %x, got %x", testData, readData)
+	}
+}
+
+type testMobileReader struct {
+	reader      io.Reader
+	returnError bool
+}
+
+func (r *testMobileReader) Read(max int) (*MobileReadResult, error) {
+	if r.returnError {
+		return nil, errors.New("gopenpgp: test - forced error while reading")
+	}
+	buf := make([]byte, max)
+	n, err := r.reader.Read(buf)
+	eof := false
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			eof = true
+		} else {
+			return nil, errors.New("gopenpgp: test - error while reading")
+		}
+	}
+	return NewMobileReadResult(n, eof, buf[:n]), nil
+}
+
+func TestMobile2GoReader(t *testing.T) {
+	testData := []byte("Hello World!")
+	reader := NewMobile2GoReader(&testMobileReader{bytes.NewReader(testData), false})
+	var readData []byte
+	bufSize := 2
+	readBuf := make([]byte, bufSize)
+	reachedEnd := false
+	for !reachedEnd {
+		n, err := reader.Read(readBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				reachedEnd = true
+			} else {
+				t.Fatal("Expected no error while reading, got:", err)
+			}
+		}
+		if n > 0 {
+			readData = append(readData, readBuf[:n]...)
+		}
+	}
+	if !bytes.Equal(testData, readData) {
+		t.Fatalf("expected data to be %x, got %x", testData, readData)
+	}
+	readerErr := NewMobile2GoReader(&testMobileReader{bytes.NewReader(testData), true})
+	if _, err := readerErr.Read(readBuf); err == nil {
+		t.Fatal("expected an error while reading, got nil")
+	}
+}

--- a/helper/mobile_stream_test.go
+++ b/helper/mobile_stream_test.go
@@ -91,16 +91,16 @@ func TestGo2MobileReader(t *testing.T) {
 	reader := NewGo2MobileReader(bytes.NewReader(testData))
 	var readData []byte
 	bufSize := 2
+	buffer := make([]byte, bufSize)
 	reachedEnd := false
 	for !reachedEnd {
-		res, err := reader.Read(bufSize)
+		n, err := reader.Read(buffer)
 		if err != nil {
 			t.Fatal("Expected no error while reading, got:", err)
 		}
-		n := res.N
-		reachedEnd = res.IsEOF
+		reachedEnd = n < 0
 		if n > 0 {
-			readData = append(readData, res.Data[:n]...)
+			readData = append(readData, buffer[:n]...)
 		}
 	}
 	if !bytes.Equal(testData, readData) {


### PR DESCRIPTION
This PR adds new methods to KeyRing and SessionKey to allow encryption/decryption and signing/verification using io.Reader and io.Writer directly instead of having to load the data in memory beforehand.
It also adds helpers for mobile apps to be able to implement Readers and Writers to be used with these methods