### PR TITLE
Release 2.1.10: Remove monotonic clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.10] 2021-06-16
+### Fixed
+- Removed time interpolation via monotonic clock that can cause signatures in the future
+
 ## [2.1.9] 2021-05-12
 ### Changed
 - Updated the underlying crypto library

--- a/crypto/time.go
+++ b/crypto/time.go
@@ -1,7 +1,6 @@
 package crypto
 
 import (
-	"errors"
 	"time"
 )
 
@@ -30,24 +29,13 @@ func GetTime() time.Time {
 
 // ----- INTERNAL FUNCTIONS -----
 
-// getNow returns current time.
+// getNow returns the latest server time.
 func getNow() time.Time {
-	extrapolate, err := getDiff()
-
-	if err != nil {
+	if pgp.latestServerTime == 0 {
 		return time.Now()
 	}
 
-	return time.Unix(pgp.latestServerTime+extrapolate, 0)
-}
-
-func getDiff() (int64, error) {
-	if pgp.latestServerTime > 0 && !pgp.latestClientTime.IsZero() {
-		// Since is monotonic, it uses a monotonic clock in this case instead of the wall clock
-		return int64(time.Since(pgp.latestClientTime).Seconds()), nil
-	}
-
-	return 0, errors.New("gopenpgp: latest server time not available")
+	return time.Unix(pgp.latestServerTime, 0)
 }
 
 // getTimeGenerator Returns a time generator function.
@@ -57,13 +45,11 @@ func getTimeGenerator() func() time.Time {
 
 // getNowKeyGenerationOffset returns the current time with the key generation offset.
 func getNowKeyGenerationOffset() time.Time {
-	extrapolate, err := getDiff()
-
-	if err != nil {
+	if pgp.latestServerTime == 0 {
 		return time.Unix(time.Now().Unix()+pgp.generationOffset, 0)
 	}
 
-	return time.Unix(pgp.latestServerTime+extrapolate+pgp.generationOffset, 0)
+	return time.Unix(pgp.latestServerTime+pgp.generationOffset, 0)
 }
 
 // getKeyGenerationTimeGenerator Returns a time generator function with the key generation offset.

--- a/crypto/time_test.go
+++ b/crypto/time_test.go
@@ -10,12 +10,8 @@ import (
 func TestTime(t *testing.T) {
 	UpdateTime(1571072494)
 	time.Sleep(1 * time.Second)
-	diff, err := getDiff()
+	now := GetUnixTime()
 
-	if err != nil {
-		t.Fatal("Expected no error when calculating time difference, got:", err)
-	}
-	assert.Exactly(t, int64(1), diff)
-
+	assert.Exactly(t, int64(1571072494), now) // Use latest server time
 	UpdateTime(testTime)
 }


### PR DESCRIPTION
Removed time interpolation via monotonic clock that can cause signatures in the future