### PR TITLE
Add a wrapper for explicit verification of decrypted streams.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added 
+- Helper to access the SignatureVerificationError explicitly when decrypting streams  in mobile apps: 
+	```go
+	func VerifySignatureExplicit(
+		reader *crypto.PlainMessageReader,
+	) (signatureVerificationError *crypto.SignatureVerificationError, err error)
+	```
+
 ## [2.2.0] 2021-06-30
 ### Added
 - Streaming API:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Changed the returned `SignatureVerificationError.Status` when trying to verify a message with no embedded signature. It used to return `constants.SIGNATURE_NO_VERIFIER` and now returns `constants.SIGNATURE_NOT_SIGNED`.
+This change impacts : 
+	- `func (sk *SessionKey) DecryptAndVerify(...)`
+	- `func (msg *PlainMessageReader) VerifySignature(...)`
+	- `func (keyRing *KeyRing) Decrypt(...)`
+
 ### Added 
 - Helper to access the SignatureVerificationError explicitly when decrypting streams  in mobile apps: 
 	```go

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -99,8 +99,10 @@ func processSignatureExpiration(md *openpgp.MessageDetails, verifyTime int64) {
 
 // verifyDetailsSignature verifies signature from message details.
 func verifyDetailsSignature(md *openpgp.MessageDetails, verifierKey *KeyRing) error {
-	if !md.IsSigned ||
-		md.SignedBy == nil ||
+	if !md.IsSigned {
+		return newSignatureNotSigned()
+	}
+	if md.SignedBy == nil ||
 		len(verifierKey.entities) == 0 ||
 		len(verifierKey.entities.KeysById(md.SignedByKeyId)) == 0 {
 		return newSignatureNoVerifier()

--- a/helper/mobile_stream.go
+++ b/helper/mobile_stream.go
@@ -180,3 +180,24 @@ func (r *Go2IOSReader) Read(max int) (result *MobileReadResult, err error) {
 	}
 	return result, nil
 }
+
+// VerifySignatureExplicit calls the reader's VerifySignature()
+// and tries to cast the returned error to a SignatureVerificationError.
+func VerifySignatureExplicit(
+	reader *crypto.PlainMessageReader,
+) (signatureVerificationError *crypto.SignatureVerificationError, err error) {
+	if reader == nil {
+		return nil, errors.New("gopenppg: the reader can't be nil")
+	}
+	err = reader.VerifySignature()
+	if err != nil {
+		castedErr := &crypto.SignatureVerificationError{}
+		isType := errors.As(err, castedErr)
+		if !isType {
+			return
+		}
+		signatureVerificationError = castedErr
+		err = nil
+	}
+	return
+}

--- a/helper/mobile_test.go
+++ b/helper/mobile_test.go
@@ -85,7 +85,7 @@ func TestMobileSignedMessageDecryptionWithSessionKey(t *testing.T) {
 		t.Fatal("Expected no error when decrypting, got:", err)
 	}
 
-	assert.Exactly(t, constants.SIGNATURE_NO_VERIFIER, decrypted.SignatureVerificationError.Status)
+	assert.Exactly(t, constants.SIGNATURE_NOT_SIGNED, decrypted.SignatureVerificationError.Status)
 	assert.Exactly(t, message.GetString(), decrypted.Message.GetString())
 
 	publicKey, _ = crypto.NewKeyFromArmored(readTestFile("keyring_publicKey", false))


### PR DESCRIPTION
Add a wrapper for the PlainMessageReader structure, that augments its VerifySignature() api with a VerifySignatureExplicit() which returns a SignatureVerificationError instead of an error when applicable.
This gives the mobile apps access to the status of the verification error.