### PR TITLE
Release version 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.2.2] 2021-08-04
 ### Added
 - `NewKeyFromEntity` to create a key from an openpgp entity
 

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,7 +3,7 @@ package constants
 
 // Constants for armored data.
 const (
-	ArmorHeaderVersion = "GopenPGP 2.2.1"
+	ArmorHeaderVersion = "GopenPGP 2.2.2"
 	ArmorHeaderComment = "https://gopenpgp.org"
 	PGPMessageHeader   = "PGP MESSAGE"
 	PGPSignatureHeader = "PGP SIGNATURE"

--- a/constants/version.go
+++ b/constants/version.go
@@ -1,3 +1,3 @@
 package constants
 
-const Version = "2.2.1"
+const Version = "2.2.2"


### PR DESCRIPTION
### Added
- `NewKeyFromEntity` to create a key from an openpgp entity

### Changed
- Improved documentation for differences between text and binary messages

### Deprecated
- `(key *Key) Check() (bool, error)` is now deprecated, all keys are now checked upon import from x/crypto

### Fixed
- Dummy keys now show the correct locked/unlocked status

### Security
- All keys are now checked on parsing from the underlying library