### PR TITLE
Fix: use verifyTime in the config time instead of Now()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Use the provided `verifyTime` instead of the current time when verifying embedded signatures.
+
 ## [2.2.3] 2021-09-21
 ### Changed
 - Keys are now generated with ZLIB as preferred compression algorithm

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -194,6 +194,7 @@ func (keyRing *KeyRing) DecryptStream(
 		message,
 		keyRing,
 		verifyKeyRing,
+		verifyTime,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When decrypting message, we have to use verifyTime in the config
otherwise signatures not valid at verifyTime but valid at Now()
will be seen as valid.