### PR TITLE
Release v2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
+## [2.2.4] 2021-09-29
 ### Fixed
-
 - Use the provided `verifyTime` instead of the current time when verifying embedded signatures.
 
 ## [2.2.3] 2021-09-21

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,7 +3,7 @@ package constants
 
 // Constants for armored data.
 const (
-	ArmorHeaderVersion = "GopenPGP 2.2.3"
+	ArmorHeaderVersion = "GopenPGP 2.2.4"
 	ArmorHeaderComment = "https://gopenpgp.org"
 	PGPMessageHeader   = "PGP MESSAGE"
 	PGPSignatureHeader = "PGP SIGNATURE"

--- a/constants/version.go
+++ b/constants/version.go
@@ -1,3 +1,3 @@
 package constants
 
-const Version = "2.2.3"
+const Version = "2.2.4"


### PR DESCRIPTION
Use the provided verifyTime instead of the current time when verifying embedded signatures.