### PR TITLE
Add support for AEADMessages in PGPMessage.SeparateKeyAndData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed bug with `NewPGPSplitMessageFromArmored(armored)` and `PGPMessage.SeparateKeyAndData()`.
+Those functions didn't parse AEAD encrypted messages correctly (eg messages encrypted with the latest versions of gnupg.), resulting in a nil `DataPacket`.
+
 ## [2.4.0] 2021-12-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed bug with `NewPGPSplitMessageFromArmored(armored)` and `PGPMessage.SeparateKeyAndData()`.
-Those functions didn't parse AEAD encrypted messages correctly (eg messages encrypted with the latest versions of gnupg.), resulting in a nil `DataPacket`.
+Those functions didn't parse AEAD encrypted messages correctly (eg messages encrypted with the latest versions of gnupg), resulting in a nil `DataPacket`.
 
 ## [2.4.0] 2021-12-21
 

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -439,3 +439,26 @@ func TestMessageGetArmoredWithEmptyHeaders(t *testing.T) {
 	assert.NotContains(t, armored, "Version")
 	assert.NotContains(t, armored, "Comment")
 }
+
+func TestPGPSplitMessageFromArmoredWithAEAD(t *testing.T) {
+	var message = `-----BEGIN PGP MESSAGE-----
+
+hF4DJDxTg/yg6TkSAQdA3Ogzuxwz7IdSRCh81gdYuB0bKqkYDs7EksOkYJ7eUnMw
+FsRNg+X3KbCj9j747An4J7V8trghOIN00dlpuR77wELS79XHoP55qmyVyPzmTXdx
+1F8BCQIQyGCAxAA1ppydoBVp7ithTEl2bU72tbOsLCFY8TBamG6t3jfqJpO2lz+G
+M0xNgvwIDrAQsN35VGw72I/FvWJ0VG3rpBKgFp5nPK0NblRomXTRRfoNgSoVUcxU
+vA==
+=YNf2
+-----END PGP MESSAGE-----
+`
+	split, err := NewPGPSplitMessageFromArmored(message)
+	if err != nil {
+		t.Errorf("Couldn't parse split message: %v", err)
+	}
+	if split.KeyPacket == nil {
+		t.Error("Key packet was nil")
+	}
+	if split.DataPacket == nil {
+		t.Error("Data packet was nil")
+	}
+}


### PR DESCRIPTION
The function PGPMessage.SeparateKeyAndData was ignoring AEAD encrypted data packets.
This MR add supports for parsing those packets when splitting messages.