### PR TITLE
Generic implementation of splitting messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- `SeparateKeyAndData` is now implemented in a more generic way, by checking for the location in the bytes of the last session key packet, then splitting the binary message after that point.
+
+### Fixed
+- `SeparateKeyAndData` now correctly parses AEAD packets.
+- `(ap *AttachmentProcessor) Finish()` now returns encryption errors correctly.
+
+
 ## [2.4.2] 2022-01-13
 
 ### Changed

--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -70,7 +70,7 @@ func (ap *AttachmentProcessor) Finish() (*PGPSplitMessage, error) {
 // newAttachmentProcessor creates an AttachmentProcessor which can be used to encrypt
 // a file. It takes an estimatedSize and fileName as hints about the file.
 func (keyRing *KeyRing) newAttachmentProcessor(
-	estimatedSize int, filename string, isBinary bool, modTime uint32, garbageCollector int,
+	estimatedSize int, filename string, isBinary bool, modTime uint32, garbageCollector int, //nolint:unparam
 ) (*AttachmentProcessor, error) {
 	attachmentProc := &AttachmentProcessor{}
 	// You could also add these one at a time if needed.

--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -96,7 +96,7 @@ func (keyRing *KeyRing) newAttachmentProcessor(
 		message := &PGPMessage{
 			Data: ciphertext,
 		}
-		split, splitError := message.SeparateKeyAndData(estimatedSize, garbageCollector)
+		split, splitError := message.SeparateKeyAndData()
 		if attachmentProc.err == nil {
 			attachmentProc.err = splitError
 		}

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -96,7 +96,7 @@ func TestTextMessageEncryption(t *testing.T) {
 		t.Fatal("Expected no error when encrypting, got:", err)
 	}
 
-	split, err := ciphertext.SeparateKeyAndData(1024, 0)
+	split, err := ciphertext.SeparateKeyAndData()
 	if err != nil {
 		t.Fatal("Expected no error when splitting, got:", err)
 	}
@@ -120,7 +120,7 @@ func TestTextMessageEncryptionWithCompression(t *testing.T) {
 		t.Fatal("Expected no error when encrypting, got:", err)
 	}
 
-	split, err := ciphertext.SeparateKeyAndData(1024, 0)
+	split, err := ciphertext.SeparateKeyAndData()
 	if err != nil {
 		t.Fatal("Expected no error when splitting, got:", err)
 	}
@@ -252,7 +252,7 @@ func TestDummy(t *testing.T) {
 		t.Fatal("Expected no error when encrypting, got:", err)
 	}
 
-	split, err := ciphertext.SeparateKeyAndData(1024, 0)
+	split, err := ciphertext.SeparateKeyAndData()
 	if err != nil {
 		t.Fatal("Expected no error when splitting, got:", err)
 	}

--- a/crypto/sessionkey_test.go
+++ b/crypto/sessionkey_test.go
@@ -253,7 +253,7 @@ func TestDataPacketDecryption(t *testing.T) {
 		t.Fatal("Expected no error when unarmoring, got:", err)
 	}
 
-	split, err := pgpMessage.SeparateKeyAndData(1024, 0)
+	split, err := pgpMessage.SeparateKeyAndData(1024, 0) // Test passing parameters for backwards compatibility
 	if err != nil {
 		t.Fatal("Expected no error when splitting, got:", err)
 	}


### PR DESCRIPTION
This implements `SeparateKeyAndData` in a more generic way, by checking for the location in the bytes of the last session key packet, and then splitting the binary message after that point.

This indirectly adds support for multiple session key packets, symmetric session key packets, and fixes support for AEAD encrypted data packets (re-serialization of AEAD packets was broken).