### PR TITLE
Create `SplitMessage()` to replace `SeparateKeyAndData(...int)`

### DIFF
--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -96,7 +96,7 @@ func (keyRing *KeyRing) newAttachmentProcessor(
 		message := &PGPMessage{
 			Data: ciphertext,
 		}
-		split, splitError := message.SeparateKeyAndData()
+		split, splitError := message.SplitMessage()
 		if attachmentProc.err == nil {
 			attachmentProc.err = splitError
 		}

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -140,7 +140,7 @@ func NewPGPSplitMessageFromArmored(encrypted string) (*PGPSplitMessage, error) {
 		return nil, err
 	}
 
-	return message.SeparateKeyAndData()
+	return message.SplitMessage()
 }
 
 // NewPGPSignature generates a new PGPSignature from the unarmored binary data.
@@ -324,9 +324,9 @@ func (msg *PGPSplitMessage) GetPGPMessage() *PGPMessage {
 	return NewPGPMessage(append(msg.KeyPacket, msg.DataPacket...))
 }
 
-// SeparateKeyAndData splits the message into key and data packet(s).
+// SplitMessage splits the message into key and data packet(s).
 // Parameters are for backwards compatibility and are unused.
-func (msg *PGPMessage) SeparateKeyAndData(_ ...int) (*PGPSplitMessage, error) {
+func (msg *PGPMessage) SplitMessage() (*PGPSplitMessage, error) {
 	bytesReader := bytes.NewReader(msg.Data)
 	packets := packet.NewReader(bytesReader)
 	splitPoint := int64(0)
@@ -350,6 +350,13 @@ Loop:
 		KeyPacket:  clone(msg.Data[:splitPoint]),
 		DataPacket: clone(msg.Data[splitPoint:]),
 	}, nil
+}
+
+// SeparateKeyAndData splits the message into key and data packet(s).
+// Parameters are for backwards compatibility and are unused.
+// Deprecated in favor of SplitMessage().
+func (msg *PGPMessage) SeparateKeyAndData(_ int, _ int) (*PGPSplitMessage, error) {
+	return msg.SplitMessage()
 }
 
 // GetBinary returns the unarmored binary content of the signature as a []byte.

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -354,7 +354,7 @@ Loop:
 
 // SeparateKeyAndData splits the message into key and data packet(s).
 // Parameters are for backwards compatibility and are unused.
-// Deprecated in favor of SplitMessage().
+// Deprecated: use SplitMessage().
 func (msg *PGPMessage) SeparateKeyAndData(_ int, _ int) (*PGPSplitMessage, error) {
 	return msg.SplitMessage()
 }

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -96,7 +96,7 @@ func TestTextMessageEncryption(t *testing.T) {
 		t.Fatal("Expected no error when encrypting, got:", err)
 	}
 
-	split, err := ciphertext.SeparateKeyAndData()
+	split, err := ciphertext.SplitMessage()
 	if err != nil {
 		t.Fatal("Expected no error when splitting, got:", err)
 	}
@@ -120,7 +120,7 @@ func TestTextMessageEncryptionWithCompression(t *testing.T) {
 		t.Fatal("Expected no error when encrypting, got:", err)
 	}
 
-	split, err := ciphertext.SeparateKeyAndData()
+	split, err := ciphertext.SplitMessage()
 	if err != nil {
 		t.Fatal("Expected no error when splitting, got:", err)
 	}
@@ -252,7 +252,7 @@ func TestDummy(t *testing.T) {
 		t.Fatal("Expected no error when encrypting, got:", err)
 	}
 
-	split, err := ciphertext.SeparateKeyAndData()
+	split, err := ciphertext.SplitMessage()
 	if err != nil {
 		t.Fatal("Expected no error when splitting, got:", err)
 	}

--- a/crypto/sessionkey_test.go
+++ b/crypto/sessionkey_test.go
@@ -278,7 +278,7 @@ func TestMDCFailDecryption(t *testing.T) {
 		t.Fatal("Expected no error when unarmoring, got:", err)
 	}
 
-	split, err := pgpMessage.SeparateKeyAndData()
+	split, err := pgpMessage.SplitMessage()
 	if err != nil {
 		t.Fatal("Expected no error when splitting, got:", err)
 	}


### PR DESCRIPTION
Keep `SeparateKeyAndData(_ int, _ int)` for backwards compatibility with go-mobile bindings.
Deprecate `SeparateKeyAndData` in favor of `SplitMessage`.