### PR TITLE
Detached sign text messages with signature type text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated `github.com/ProtonMail/go-mime` to latest versions, which cleans up uneeded dependencies. And fix an issue with PGP/MIME messages with non standard encodings.
 - Sanitize strings returned in `MIMECallbacks.OnBody()` and `PlainMessage.GetString()`. Strings that have non utf8 characters will be sanitized to have the "character unknown" character : � instead.
+- Detached sign text messages with signature type text. Similarly, clearsigned messages now also use signature type text.
 
 ## [2.4.10] 2022-08-22
 ### Changed

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -69,8 +69,12 @@ func (keyRing *KeyRing) SignDetached(message *PlainMessage) (*PGPSignature, erro
 
 	config := &packet.Config{DefaultHash: crypto.SHA512, Time: getTimeGenerator()}
 	var outBuf bytes.Buffer
-	// sign bin
-	if err := openpgp.DetachSign(&outBuf, signEntity, message.NewReader(), config); err != nil {
+	if message.IsBinary() {
+		err = openpgp.DetachSign(&outBuf, signEntity, message.NewReader(), config)
+	} else {
+		err = openpgp.DetachSignText(&outBuf, signEntity, message.NewReader(), config)
+	}
+	if err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: error in signing")
 	}
 


### PR DESCRIPTION
Fix #198. This is required to fix https://github.com/ProtonMail/gosop/issues/10. Also, `SignDetached()` is used for clearsigned messages as well, where using binary type signatures is a bit strange. This fixes that as well.