### PR TITLE
Update go crypto, and improve signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+# Changed
+- Update `github.com/ProtonMail/go-crypto` to the latest version
+- More strictly verify detached signatures: reject detached signatures from revoked and expired keys.
+- In `GetVerifiedSignatureTimestamp`, use the new `VerifyDetachedSignatureAndHash` function to get the verified signature, instead of parsing the signature packets manually to get the timestamp.
+
 ## [2.5.2] 2022-01-25
 # Changed
 - Update `github.com/ProtonMail/go-crypto` to the latest version

--- a/crypto/keyring_streaming.go
+++ b/crypto/keyring_streaming.go
@@ -324,12 +324,13 @@ func (keyRing *KeyRing) VerifyDetachedStream(
 	signature *PGPSignature,
 	verifyTime int64,
 ) error {
-	return verifySignature(
+	_, err := verifySignature(
 		keyRing.entities,
 		message,
 		signature.GetBinary(),
 		verifyTime,
 	)
+	return err
 }
 
 // SignDetachedEncryptedStream generates and returns a PGPMessage

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -119,7 +119,7 @@ func verifyDetailsSignature(md *openpgp.MessageDetails, verifierKey *KeyRing) er
 }
 
 // verifySignature verifies if a signature is valid with the entity list.
-func verifySignature(pubKeyEntries openpgp.EntityList, origText io.Reader, signature []byte, verifyTime int64) error {
+func verifySignature(pubKeyEntries openpgp.EntityList, origText io.Reader, signature []byte, verifyTime int64) (*packet.Signature, error) {
 	config := &packet.Config{}
 	if verifyTime == 0 {
 		config.Time = func() time.Time {
@@ -134,9 +134,9 @@ func verifySignature(pubKeyEntries openpgp.EntityList, origText io.Reader, signa
 
 	sig, signer, err := openpgp.VerifyDetachedSignatureAndHash(pubKeyEntries, origText, signatureReader, allowedHashes, config)
 
-	if signer != nil && (errors.Is(err, pgpErrors.ErrSignatureExpired) || errors.Is(err, pgpErrors.ErrKeyExpired)) {
+	if sig != nil && signer != nil && (errors.Is(err, pgpErrors.ErrSignatureExpired) || errors.Is(err, pgpErrors.ErrKeyExpired)) {
 		if verifyTime == 0 { // Expiration check disabled
-			return nil
+			return sig, nil
 		}
 
 		// Maybe the creation time offset pushed it over the edge
@@ -147,15 +147,15 @@ func verifySignature(pubKeyEntries openpgp.EntityList, origText io.Reader, signa
 
 		_, err = signatureReader.Seek(0, io.SeekStart)
 		if err != nil {
-			return newSignatureFailed()
+			return nil, newSignatureFailed()
 		}
 
 		sig, signer, err = openpgp.VerifyDetachedSignatureAndHash(pubKeyEntries, origText, signatureReader, allowedHashes, config)
 	}
 
 	if err != nil || sig == nil || signer == nil {
-		return newSignatureFailed()
+		return nil, newSignatureFailed()
 	}
 
-	return nil
+	return sig, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ProtonMail/gopenpgp/v2
 go 1.15
 
 require (
-	github.com/ProtonMail/go-crypto v0.0.0-20230124153114-0acdc8ae009b
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8
 	github.com/ProtonMail/go-mime v0.0.0-20221031134845-8fd9bc37cf08
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ProtonMail/go-crypto v0.0.0-20230124153114-0acdc8ae009b h1:1DHH9haxfhaVM8owXQjLdn7UP4AkDfzSdiRoLdcSCqE=
-github.com/ProtonMail/go-crypto v0.0.0-20230124153114-0acdc8ae009b/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
+github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
+github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/ProtonMail/go-mime v0.0.0-20221031134845-8fd9bc37cf08 h1:dS7r5z4iGS0qCjM7UwWdsEMzQesUQbGcXdSm2/tWboA=
 github.com/ProtonMail/go-mime v0.0.0-20221031134845-8fd9bc37cf08/go.mod h1:qRZgbeASl2a9OwmsV85aWwRqic0NHPh+9ewGAzb4cgM=
 github.com/ProtonMail/go-mobile v0.0.0-20210326110230-f181c70e4e2b h1:XVeh08xp93T+xK6rzpCSQTZ+LwEo+ASHvOifrQ5ZgEE=


### PR DESCRIPTION
- Update go-crypto
- More strictly verify detached signatures: reject detached signatures from revoked and expired keys.
- In `GetVerifiedSignatureTimestamp`, use the new `VerifyDetachedSignatureAndHash` to get the verified signature, instead of parsing the signature packets manually to get the timestamp.