### PR TITLE
Wrap the cause of signature verification errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- The `SignatureVerificationError` struct now has a `Cause error` field, which is returned by the the Unwrap function. The cause is also included in the error message.
+	NB: If the caller was relying on the exact message of the error, it might break the flow.
+
 ## [2.6.1] 2023-03-22
 
 ### Security fix

--- a/crypto/mime_test.go
+++ b/crypto/mime_test.go
@@ -303,7 +303,7 @@ func TestMessageVerificationNotSignedNoVerifier(t *testing.T) {
 
 func TestMessageVerificationNotSignedFailed(t *testing.T) {
 	callbackResults := runScenario(t, "testdata/mime/scenario_13.asc")
-	var expectedErrors = []SignatureVerificationError{newSignatureNotSigned(), newSignatureFailed()}
+	var expectedErrors = []SignatureVerificationError{newSignatureNotSigned(), newSignatureFailed(nil)}
 	compareErrors(expectedErrors, callbackResults.onError, t)
 	expectedStatus := []int{3}
 	compareStatus(expectedStatus, callbackResults.onVerified, t)
@@ -335,7 +335,7 @@ func TestMessageVerificationNoVerifierNoVerifier(t *testing.T) {
 
 func TestMessageVerificationNoVerifierFailed(t *testing.T) {
 	callbackResults := runScenario(t, "testdata/mime/scenario_23.asc")
-	var expectedErrors = []SignatureVerificationError{newSignatureNoVerifier(), newSignatureFailed()}
+	var expectedErrors = []SignatureVerificationError{newSignatureNoVerifier(), newSignatureFailed(nil)}
 	compareErrors(expectedErrors, callbackResults.onError, t)
 	expectedStatus := []int{3}
 	compareStatus(expectedStatus, callbackResults.onVerified, t)

--- a/crypto/signature_collector.go
+++ b/crypto/signature_collector.go
@@ -110,7 +110,7 @@ func (sc *SignatureCollector) Accept(
 		case errors.Is(err, pgpErrors.ErrUnknownIssuer):
 			sc.verified = newSignatureNoVerifier()
 		default:
-			sc.verified = newSignatureFailed()
+			sc.verified = newSignatureFailed(err)
 		}
 	} else {
 		sc.verified = newSignatureNoVerifier()


### PR DESCRIPTION
Instead of swallowing the cause of verification errors, we use error wrapping to communicate the cause to the caller.