### PR TITLE
Add SIGNATURE_BAD_CONTEXT status to verification error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `SignatureVerificationError` struct now has a `Cause error` field, which is returned by the the Unwrap function. The cause is also included in the error message.
 	NB: If the caller was relying on the exact message of the error, it might break the flow.
+- When a signature fails verification because of the signature context, it returns a `SignatureVerificationError` with 
+status `constants.SIGNATURE_BAD_CONTEXT` instead of `constants.SIGNATURE_FAILED`.
 
 ## [2.6.1] 2023-03-22
 

--- a/constants/cipher.go
+++ b/constants/cipher.go
@@ -15,6 +15,7 @@ const (
 	SIGNATURE_NOT_SIGNED  int = 1
 	SIGNATURE_NO_VERIFIER int = 2
 	SIGNATURE_FAILED      int = 3
+	SIGNATURE_BAD_CONTEXT int = 4
 )
 
 const DefaultCompression = 2      // ZLIB

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -3,7 +3,6 @@ package crypto
 import (
 	"bytes"
 	"crypto"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -12,6 +11,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	pgpErrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/pkg/errors"
 
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/internal"
@@ -51,6 +51,14 @@ func (e SignatureVerificationError) Unwrap() error {
 
 // newSignatureFailed creates a new SignatureVerificationError, type
 // SignatureFailed.
+func newSignatureBadContext(cause error) SignatureVerificationError {
+	return SignatureVerificationError{
+		Status:  constants.SIGNATURE_BAD_CONTEXT,
+		Message: "Invalid signature context",
+		Cause:   cause,
+	}
+}
+
 func newSignatureFailed(cause error) SignatureVerificationError {
 	return SignatureVerificationError{
 		Status:  constants.SIGNATURE_FAILED,
@@ -266,7 +274,7 @@ func verifySignature(
 	if verificationContext != nil {
 		err := verificationContext.verifyContext(sig)
 		if err != nil {
-			return nil, newSignatureFailed(err)
+			return nil, newSignatureBadContext(err)
 		}
 	}
 

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -75,7 +75,7 @@ func TestVerifyTextDetachedSig(t *testing.T) {
 	}
 }
 
-func checkVerificationError(t *testing.T, err error, expectedStatus int) { //nolint: unparam
+func checkVerificationError(t *testing.T, err error, expectedStatus int) {
 	if err == nil {
 		t.Fatalf("Expected a verification error")
 	}
@@ -435,7 +435,7 @@ func Test_VerifyDetachedWithWrongContext(t *testing.T) {
 		verificationContext,
 	)
 	// then
-	checkVerificationError(t, err, constants.SIGNATURE_FAILED)
+	checkVerificationError(t, err, constants.SIGNATURE_BAD_CONTEXT)
 }
 
 func Test_VerifyDetachedWithMissingNonRequiredContext(t *testing.T) {
@@ -491,7 +491,7 @@ func Test_VerifyDetachedWithMissingRequiredContext(t *testing.T) {
 		verificationContext,
 	)
 	// then
-	checkVerificationError(t, err, constants.SIGNATURE_FAILED)
+	checkVerificationError(t, err, constants.SIGNATURE_BAD_CONTEXT)
 }
 
 func Test_VerifyDetachedWithMissingRequiredContextBeforeCutoff(t *testing.T) {
@@ -561,7 +561,7 @@ func Test_VerifyDetachedWithMissingRequiredContextAfterCutoff(t *testing.T) {
 		verificationContext,
 	)
 	// then
-	checkVerificationError(t, err, constants.SIGNATURE_FAILED)
+	checkVerificationError(t, err, constants.SIGNATURE_BAD_CONTEXT)
 }
 
 func Test_VerifyDetachedWithDoubleContext(t *testing.T) {
@@ -587,5 +587,5 @@ func Test_VerifyDetachedWithDoubleContext(t *testing.T) {
 		verificationContext,
 	)
 	// then
-	checkVerificationError(t, err, constants.SIGNATURE_FAILED)
+	checkVerificationError(t, err, constants.SIGNATURE_BAD_CONTEXT)
 }


### PR DESCRIPTION
 Add a special status for verification errors that are caused by the signature context.
 PR built on top of https://github.com/ProtonMail/gopenpgp/pull/224