### PR TITLE
Add mobile helpers to verify signature contexts and prepare v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] 2023-04-21
+
+- Add mobile helpers for signature verification with contexts.
+
 ## [2.7.0] 2023-04-14
 ### Changed
 - The `SignatureVerificationError` struct now has a `Cause error` field, which is returned by the the Unwrap function. The cause is also included in the error message.

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,7 +3,7 @@ package constants
 
 // Constants for armored data.
 const (
-	ArmorHeaderVersion = "GopenPGP 2.7.0"
+	ArmorHeaderVersion = "GopenPGP 2.7.1"
 	ArmorHeaderComment = "https://gopenpgp.org"
 	PGPMessageHeader   = "PGP MESSAGE"
 	PGPSignatureHeader = "PGP SIGNATURE"

--- a/constants/version.go
+++ b/constants/version.go
@@ -1,3 +1,3 @@
 package constants
 
-const Version = "2.7.0"
+const Version = "2.7.1"

--- a/helper/mobile.go
+++ b/helper/mobile.go
@@ -26,6 +26,20 @@ func DecryptExplicitVerify(
 	return newExplicitVerifyMessage(message, err)
 }
 
+// DecryptExplicitVerifyWithContext decrypts a PGP message given a private keyring
+// and a public keyring to verify the embedded signature. Returns the plain
+// data and an error on signature verification failure.
+// The caller can provide a context that will be used to verify the signature.
+func DecryptExplicitVerifyWithContext(
+	pgpMessage *crypto.PGPMessage,
+	privateKeyRing, publicKeyRing *crypto.KeyRing,
+	verifyTime int64,
+	verificationContext *crypto.VerificationContext,
+) (*ExplicitVerifyMessage, error) {
+	message, err := privateKeyRing.DecryptWithContext(pgpMessage, publicKeyRing, verifyTime, verificationContext)
+	return newExplicitVerifyMessage(message, err)
+}
+
 // DecryptSessionKeyExplicitVerify decrypts a PGP data packet given a session key
 // and a public keyring to verify the embedded signature. Returns the plain data and
 // an error on signature verification failure.
@@ -36,6 +50,21 @@ func DecryptSessionKeyExplicitVerify(
 	verifyTime int64,
 ) (*ExplicitVerifyMessage, error) {
 	message, err := sessionKey.DecryptAndVerify(dataPacket, publicKeyRing, verifyTime)
+	return newExplicitVerifyMessage(message, err)
+}
+
+// DecryptSessionKeyExplicitVerifyWithContext decrypts a PGP data packet given a session key
+// and a public keyring to verify the embedded signature. Returns the plain data and
+// an error on signature verification failure.
+// The caller can provide a context that will be used to verify the signature.
+func DecryptSessionKeyExplicitVerifyWithContext(
+	dataPacket []byte,
+	sessionKey *crypto.SessionKey,
+	publicKeyRing *crypto.KeyRing,
+	verifyTime int64,
+	verificationContext *crypto.VerificationContext,
+) (*ExplicitVerifyMessage, error) {
+	message, err := sessionKey.DecryptAndVerifyWithContext(dataPacket, publicKeyRing, verifyTime, verificationContext)
 	return newExplicitVerifyMessage(message, err)
 }
 


### PR DESCRIPTION
Add the mobile helpers to verify message signatures with contexts.

Prepare the release of v2.7.1
