### PR TITLE
Cleanup fixed time and allow using time offset for crypto operations

### DIFF
--- a/crypto/attachment.go
+++ b/crypto/attachment.go
@@ -85,7 +85,7 @@ func (keyRing *KeyRing) newAttachmentProcessor(
 
 	config := &packet.Config{
 		DefaultCipher: packet.CipherAES256,
-		Time:          getTimeGenerator(),
+		Time:          GetTime,
 	}
 
 	reader, writer := io.Pipe()
@@ -163,7 +163,7 @@ func (keyRing *KeyRing) DecryptAttachment(message *PGPSplitMessage) (*PlainMessa
 
 	encryptedReader := io.MultiReader(keyReader, dataReader)
 
-	config := &packet.Config{Time: getTimeGenerator()}
+	config := &packet.Config{Time: GetTime}
 
 	md, err := openpgp.ReadMessage(encryptedReader, privKeyEntries, nil, config)
 	if err != nil {

--- a/crypto/attachment_manual.go
+++ b/crypto/attachment_manual.go
@@ -95,7 +95,7 @@ func (keyRing *KeyRing) NewManualAttachmentProcessor(
 	// encryption config
 	config := &packet.Config{
 		DefaultCipher: packet.CipherAES256,
-		Time:          getTimeGenerator(),
+		Time:          GetTime,
 	}
 
 	// goroutine that reads the key packet

--- a/crypto/attachment_manual_test.go
+++ b/crypto/attachment_manual_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 func TestManualAttachmentProcessor(t *testing.T) {
-	pgp.latestServerTime = 1615394034
-	defer func() { pgp.latestServerTime = testTime }()
+	defer setFixedTime(testTime)
+	setFixedTime(1615394034)
+
 	passphrase := []byte("wUMuF/lkDPYWH/0ZqqY8kJKw7YJg6kS")
 	pk, err := NewKeyFromArmored(readTestFile("att_key", false))
 	if err != nil {
@@ -86,8 +87,8 @@ func TestManualAttachmentProcessor(t *testing.T) {
 }
 
 func TestManualAttachmentProcessorNotEnoughBuffer(t *testing.T) {
-	pgp.latestServerTime = 1615394034
-	defer func() { pgp.latestServerTime = testTime }()
+	defer setFixedTime(testTime)
+	setFixedTime(1615394034)
 	passphrase := []byte("wUMuF/lkDPYWH/0ZqqY8kJKw7YJg6kS")
 	pk, err := NewKeyFromArmored(readTestFile("att_key", false))
 	if err != nil {
@@ -141,8 +142,9 @@ func TestManualAttachmentProcessorNotEnoughBuffer(t *testing.T) {
 }
 
 func TestManualAttachmentProcessorEmptyBuffer(t *testing.T) {
-	pgp.latestServerTime = 1615394034
-	defer func() { pgp.latestServerTime = testTime }()
+	defer setFixedTime(testTime)
+	setFixedTime(1615394034)
+
 	passphrase := []byte("wUMuF/lkDPYWH/0ZqqY8kJKw7YJg6kS")
 	pk, err := NewKeyFromArmored(readTestFile("att_key", false))
 	if err != nil {

--- a/crypto/base_test.go
+++ b/crypto/base_test.go
@@ -27,7 +27,7 @@ func readTestFile(name string, trimNewlines bool) string {
 }
 
 func init() {
-	UpdateTime(testTime) // 2019-05-13T13:37:07+00:00
+	setFixedTime(testTime) // 2019-05-13T13:37:07+00:00
 
 	initGenerateKeys()
 	initArmoredKeys()

--- a/crypto/gopenpgp.go
+++ b/crypto/gopenpgp.go
@@ -6,13 +6,15 @@ import "sync"
 // GopenPGP is used as a "namespace" for many of the functions in this package.
 // It is a struct that keeps track of time skew between server and client.
 type GopenPGP struct {
-	latestServerTime int64
+	fixedTime        int64
+	timeOffset       int64
 	generationOffset int64
 	lock             *sync.RWMutex
 }
 
 var pgp = GopenPGP{
-	latestServerTime: 0,
+	fixedTime:        0,
+	timeOffset:       0,
 	generationOffset: 0,
 	lock:             &sync.RWMutex{},
 }

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -264,26 +264,26 @@ func (key *Key) GetPublicKey() (b []byte, err error) {
 
 // CanVerify returns true if any of the subkeys can be used for verification.
 func (key *Key) CanVerify() bool {
-	_, canVerify := key.entity.SigningKey(getNow())
+	_, canVerify := key.entity.SigningKey(GetTime())
 	return canVerify
 }
 
 // CanEncrypt returns true if any of the subkeys can be used for encryption.
 func (key *Key) CanEncrypt() bool {
-	_, canEncrypt := key.entity.EncryptionKey(getNow())
+	_, canEncrypt := key.entity.EncryptionKey(GetTime())
 	return canEncrypt
 }
 
 // IsExpired checks whether the key is expired.
 func (key *Key) IsExpired() bool {
 	i := key.entity.PrimaryIdentity()
-	return key.entity.PrimaryKey.KeyExpired(i.SelfSignature, getNow()) || // primary key has expired
-		i.SelfSignature.SigExpired(getNow()) // user ID self-signature has expired
+	return key.entity.PrimaryKey.KeyExpired(i.SelfSignature, GetTime()) || // primary key has expired
+		i.SelfSignature.SigExpired(GetTime()) // user ID self-signature has expired
 }
 
 // IsRevoked checks whether the key or the primary identity has a valid revocation signature.
 func (key *Key) IsRevoked() bool {
-	return key.entity.Revoked(getNow()) || key.entity.PrimaryIdentity().Revoked(getNow())
+	return key.entity.Revoked(GetTime()) || key.entity.PrimaryIdentity().Revoked(GetTime())
 }
 
 // IsPrivate returns true if the key is private.
@@ -447,7 +447,7 @@ func generateKey(
 	cfg := &packet.Config{
 		Algorithm:              packet.PubKeyAlgoRSA,
 		RSABits:                bits,
-		Time:                   getKeyGenerationTimeGenerator(),
+		Time:                   getKeyGenerationTime,
 		DefaultHash:            crypto.SHA256,
 		DefaultCipher:          packet.CipherAES256,
 		DefaultCompressionAlgo: packet.CompressionZLIB,

--- a/crypto/keyring_message.go
+++ b/crypto/keyring_message.go
@@ -241,7 +241,7 @@ func asymmetricEncryptStream(
 ) (encryptWriter io.WriteCloser, err error) {
 	config := &packet.Config{
 		DefaultCipher: packet.CipherAES256,
-		Time:          getTimeGenerator(),
+		Time:          GetTime,
 	}
 
 	if compress {
@@ -337,7 +337,7 @@ func asymmetricDecryptStream(
 					but the caller will remove signature expiration errors later on.
 					See processSignatureExpiration().
 				*/
-				return getNow()
+				return GetTime()
 			}
 			return time.Unix(verifyTime, 0)
 		},

--- a/crypto/keyring_session.go
+++ b/crypto/keyring_session.go
@@ -80,7 +80,7 @@ func (keyRing *KeyRing) EncryptSessionKey(sk *SessionKey) ([]byte, error) {
 
 	pubKeys := make([]*packet.PublicKey, 0, len(keyRing.entities))
 	for _, e := range keyRing.entities {
-		encryptionKey, ok := e.EncryptionKey(getNow())
+		encryptionKey, ok := e.EncryptionKey(GetTime())
 		if !ok {
 			return nil, errors.New("gopenpgp: encryption key is unavailable for key id " + strconv.FormatUint(e.PrimaryKey.KeyId, 16))
 		}

--- a/crypto/keyring_test.go
+++ b/crypto/keyring_test.go
@@ -236,11 +236,10 @@ func TestKeyringCapabilities(t *testing.T) {
 }
 
 func TestVerificationTime(t *testing.T) {
+	defer setFixedTime(testTime)
+	setFixedTime(1632312383)
 	message := NewPlainMessageFromString("Hello")
-	pgp.latestServerTime = 1632312383
-	defer func() {
-		pgp.latestServerTime = testTime
-	}()
+
 	enc, err := keyRingTestPublic.Encrypt(
 		message,
 		keyRingTestPrivate,

--- a/crypto/message_test.go
+++ b/crypto/message_test.go
@@ -211,10 +211,8 @@ func TestBinaryMessageEncryption(t *testing.T) {
 }
 
 func TestIssue11(t *testing.T) {
-	pgp.latestServerTime = 1559655272
-	defer func() {
-		pgp.latestServerTime = testTime
-	}()
+	defer setFixedTime(testTime)
+	setFixedTime(1559655272)
 
 	var issue11Password = []byte("1234")
 
@@ -258,8 +256,8 @@ func TestIssue11(t *testing.T) {
 }
 
 func TestDummy(t *testing.T) {
-	pgp.latestServerTime = 1636644417
-	defer func() { pgp.latestServerTime = testTime }()
+	defer setFixedTime(testTime)
+	setFixedTime(1636644417)
 
 	dummyKey, err := NewKeyFromArmored(readTestFile("key_dummy", false))
 	if err != nil {

--- a/crypto/mime.go
+++ b/crypto/mime.go
@@ -86,7 +86,10 @@ func parseMIME(
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "gopenpgp: error in reading message")
 	}
-	config := &packet.Config{DefaultCipher: packet.CipherAES256, Time: getTimeGenerator()}
+	config := &packet.Config{
+		DefaultCipher: packet.CipherAES256,
+		Time:          GetTime,
+	}
 
 	h := textproto.MIMEHeader(mm.Header)
 	mmBodyData, err := ioutil.ReadAll(mm.Body)

--- a/crypto/password.go
+++ b/crypto/password.go
@@ -93,6 +93,7 @@ func EncryptSessionKeyWithPassword(sk *SessionKey, password []byte) ([]byte, err
 
 	config := &packet.Config{
 		DefaultCipher: cf,
+		Time:          GetTime,
 	}
 
 	err = packet.SerializeSymmetricKeyEncryptedReuseKey(outbuf, sk.Key, password, config)
@@ -109,7 +110,7 @@ func passwordEncrypt(message *PlainMessage, password []byte) ([]byte, error) {
 
 	config := &packet.Config{
 		DefaultCipher: packet.CipherAES256,
-		Time:          getTimeGenerator(),
+		Time:          GetTime,
 	}
 
 	hints := &openpgp.FileHints{
@@ -148,7 +149,7 @@ func passwordDecrypt(encryptedIO io.Reader, password []byte) (*PlainMessage, err
 	}
 
 	config := &packet.Config{
-		Time: getTimeGenerator(),
+		Time: GetTime,
 	}
 
 	var emptyKeyRing openpgp.EntityList

--- a/crypto/sessionkey.go
+++ b/crypto/sessionkey.go
@@ -71,7 +71,10 @@ func (sk *SessionKey) GetBase64Key() string {
 
 // RandomToken generates a random token with the specified key size.
 func RandomToken(size int) ([]byte, error) {
-	config := &packet.Config{DefaultCipher: packet.CipherAES256}
+	config := &packet.Config{
+		DefaultCipher: packet.CipherAES256,
+		Time:          GetTime,
+	}
 	symKey := make([]byte, size)
 	if _, err := io.ReadFull(config.Random(), symKey); err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: error in generating random token")
@@ -225,7 +228,7 @@ func encryptStreamWithSessionKey(
 	}
 
 	config := &packet.Config{
-		Time:          getTimeGenerator(),
+		Time:          GetTime,
 		DefaultCipher: dc,
 	}
 
@@ -426,7 +429,7 @@ func decryptStreamWithSessionKey(
 	}
 
 	config := &packet.Config{
-		Time: getTimeGenerator(),
+		Time: GetTime,
 	}
 
 	if verificationContext != nil {

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -306,7 +306,7 @@ func signMessageDetached(
 ) (*PGPSignature, error) {
 	config := &packet.Config{
 		DefaultHash: crypto.SHA512,
-		Time:        getTimeGenerator(),
+		Time:        GetTime,
 	}
 
 	signEntity, err := signKeyRing.getSigningEntity()

--- a/crypto/time_test.go
+++ b/crypto/time_test.go
@@ -7,11 +7,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTime(t *testing.T) {
+func Test_setFixedTime(t *testing.T) {
+	defer setFixedTime(testTime)
+	setFixedTime(1571072494)
+	time.Sleep(1 * time.Second)
+	now := GetUnixTime()
+
+	assert.Exactly(t, int64(1571072494), now) // Use fixed time
+}
+
+func Test_UpdateTime(t *testing.T) {
+	defer setFixedTime(testTime)
 	UpdateTime(1571072494)
 	time.Sleep(1 * time.Second)
 	now := GetUnixTime()
 
-	assert.Exactly(t, int64(1571072494), now) // Use latest server time
-	UpdateTime(testTime)
+	assert.Exactly(t, int64(1571072494), now) // Use fixed time
+
+	UpdateTime(1571072490)
+	now = GetUnixTime()
+
+	assert.Exactly(t, int64(1571072494), now) // Use previous fixed time, ignoring time before previous
+
+	UpdateTime(1571072495)
+	now = GetUnixTime()
+
+	assert.Exactly(t, int64(1571072495), now) // Use updated fixed time
+}
+
+func Test_TimeOffset(t *testing.T) {
+	defer setFixedTime(testTime)
+	defer SetTimeOffset(0)
+	setFixedTime(testTime)
+	SetTimeOffset(30)
+	time.Sleep(1 * time.Second)
+	now := GetUnixTime()
+
+	assert.Exactly(t, int64(testTime), now) // Use fixed time without offset
+
+	setFixedTime(0)
+	SetTimeOffset(0)
+	now = GetUnixTime()
+	SetTimeOffset(30)
+
+	assert.GreaterOrEqual(t, GetUnixTime(), now+30) // Use offset with no fixed time
 }

--- a/helper/base_test.go
+++ b/helper/base_test.go
@@ -3,8 +3,6 @@ package helper
 import (
 	"io/ioutil"
 	"strings"
-
-	"github.com/ProtonMail/gopenpgp/v2/crypto"
 )
 
 const testTime = 1557754627 // 2019-05-13T13:37:07+00:00
@@ -24,5 +22,5 @@ func readTestFile(name string, trimNewlines bool) string {
 var testMailboxPassword = []byte("apple")
 
 func init() {
-	crypto.UpdateTime(testTime) // 2019-05-13T13:37:07+00:00
+	crypto.setFixedTime(testTime) // 2019-05-13T13:37:07+00:00
 }


### PR DESCRIPTION
Rename "latestServerTime" to "fixedTime" which better describes actual behavior (it was already setting fixed time for all time related operations). Allow using custom time offset for all time related operations in order to compensate client and server time difference.