### PR TITLE
packet.Config.Time should return time with 999999999 nsec

### DIFF
--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -240,7 +240,7 @@ func verifySignature(
 		}
 	} else {
 		config.Time = func() time.Time {
-			return time.Unix(verifyTime+internal.CreationTimeOffset, 0)
+			return time.Unix(verifyTime+internal.CreationTimeOffset, 999999999)
 		}
 	}
 
@@ -258,7 +258,7 @@ func verifySignature(
 			// Maybe the creation time offset pushed it over the edge
 			// Retry with the actual verification time
 			config.Time = func() time.Time {
-				return time.Unix(verifyTime, 0)
+				return time.Unix(verifyTime, 999999999)
 			}
 
 			seeker, ok := origText.(io.ReadSeeker)

--- a/crypto/time.go
+++ b/crypto/time.go
@@ -43,7 +43,7 @@ func getNow() time.Time {
 		return time.Now()
 	}
 
-	return time.Unix(pgp.latestServerTime, 0)
+	return time.Unix(pgp.latestServerTime, 999999999)
 }
 
 // getTimeGenerator Returns a time generator function.


### PR DESCRIPTION
Currently verifySignature accepts seconds for verification, but internally it uses time.Time for comparison. That means if we created openpgp.Entity with default time field, test can fail with "key expired" error because PublicKey.KeyExpired will think that key creation happened before verifyTime when in reality we just lost the nsec precision.