### PR TITLE
Ensure that DecryptSessionKey returns an error for no key packet

### DIFF
--- a/crypto/keyring_session.go
+++ b/crypto/keyring_session.go
@@ -55,7 +55,11 @@ Loop:
 	}
 
 	if !hasPacket {
-		return nil, errors.Wrap(err, "gopenpgp: couldn't find a session key packet")
+		if err != nil {
+			return nil, errors.Wrap(err, "gopenpgp: couldn't find a session key packet")
+		} else {
+			return nil, errors.New("gopenpgp: couldn't find a session key packet")
+		}
 	}
 
 	if decryptErr != nil {


### PR DESCRIPTION
`DecryptSessionKey` returns no error if the input packet stream only contains a `SymmetricallyEncrypted` packet although no session key is found. The issue is that `errors.Wrap` returns `nil` if `err` is `nil`. 

This pull request ensures that an error is returned if no session key is found. 
