### PR TITLE
Prepare release 2.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.4] 2023-10-27
+### Fixed
+- Ensure that `(SessionKey).Decrypt` functions return an error if no integrity protection is present in the encrypted input. To protect SEIPDv1 encrypted messages, SED packets must not be allowed in decryption.
+  
 ## [2.7.3] 2023-08-28
 ## Added
 - Add `helper.QuickCheckDecrypt` function to the helper package. The function allows to check with high probability if a session key can decrypt a SEIPDv1 data packet given its 24-byte prefix.

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,7 +3,7 @@ package constants
 
 // Constants for armored data.
 const (
-	ArmorHeaderVersion = "GopenPGP 2.7.3"
+	ArmorHeaderVersion = "GopenPGP 2.7.4"
 	ArmorHeaderComment = "https://gopenpgp.org"
 	PGPMessageHeader   = "PGP MESSAGE"
 	PGPSignatureHeader = "PGP SIGNATURE"

--- a/constants/version.go
+++ b/constants/version.go
@@ -1,3 +1,3 @@
 package constants
 
-const Version = "2.7.3"
+const Version = "2.7.4"


### PR DESCRIPTION
## [2.7.4] 2023-10-27
### Fixed
- Ensure that `(SessionKey).Decrypt` functions return an error if no integrity protection is present in the encrypted input. To protect SEIPDv1 encrypted messages, SED packets must not be allowed in decryption.