### PR TITLE
GopenPGP v3: Always create signature verification result

### DIFF
--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -300,7 +300,7 @@ func createVerifyResult(
 		var signatureError SignatureVerificationError
 
 		switch {
-		case len(verifierKey.entities) == 0 ||
+		case verifierKey == nil || len(verifierKey.entities) == 0 ||
 			errors.Is(signature.SignatureError, pgpErrors.ErrUnknownIssuer):
 			signatureError = newSignatureNoVerifier()
 		case signature.SignatureError != nil:

--- a/crypto/verify_reader.go
+++ b/crypto/verify_reader.go
@@ -52,11 +52,7 @@ func (msg *VerifyDataReader) VerifySignature() (result *VerifyResult, err error)
 	if !msg.readAll {
 		return nil, errors.New("gopenpgp: can't verify the signature until the message reader has been read entirely")
 	}
-	if msg.verifyKeyRing != nil {
-		return createVerifyResult(msg.details, msg.verifyKeyRing, msg.verificationContext, msg.verifyTime, msg.disableTimeCheck)
-	}
-
-	return nil, errors.New("gopenpgp: no verify keyring was provided before decryption")
+	return createVerifyResult(msg.details, msg.verifyKeyRing, msg.verificationContext, msg.verifyTime, msg.disableTimeCheck)
 }
 
 // ReadAll reads all plaintext data from the reader
@@ -82,28 +78,20 @@ func (msg *VerifyDataReader) DiscardAllAndVerifySignature() (vr *VerifyResult, e
 }
 
 // ReadAllAndVerifySignature reads all plaintext data from the reader
-// and verifies that the signatures are valid.
-// Only checks the signatures if any verify keys are present.
+// and tries to verify the signatures included in the message.
 // Returns the data in a VerifiedDataResult struct, which can be checked for signature errors.
 func (msg *VerifyDataReader) ReadAllAndVerifySignature() (*VerifiedDataResult, error) {
 	plaintext, err := msg.ReadAll()
 	if err != nil {
 		return nil, errors.Wrap(err, "gopenpgp: reading all data from reader failed")
 	}
-	if msg.verifyKeyRing != nil {
-		verifyResult, err := msg.VerifySignature()
-		return &VerifiedDataResult{
-			VerifyResult:     *verifyResult,
-			data:             plaintext,
-			metadata:         msg.GetMetadata(),
-			cachedSessionKey: msg.SessionKey(),
-		}, err
-	}
+	verifyResult, err := msg.VerifySignature()
 	return &VerifiedDataResult{
+		VerifyResult:     *verifyResult,
 		data:             plaintext,
 		metadata:         msg.GetMetadata(),
 		cachedSessionKey: msg.SessionKey(),
-	}, nil
+	}, err
 }
 
 // SessionKey returns the session key the data is decrypted with.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ProtonMail/gopenpgp/v3
 go 1.17
 
 require (
-	github.com/ProtonMail/go-crypto v1.1.0-alpha.0
+	github.com/ProtonMail/go-crypto v1.1.0-alpha.2
 	github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ProtonMail/go-crypto v1.1.0-alpha.0 h1:nHGfwXmFvJrSR9xu8qL7BkO4DqTHXE9N5vPhgY2I+j0=
-github.com/ProtonMail/go-crypto v1.1.0-alpha.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
+github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f h1:tCbYj7/299ekTTXpdwKYF8eBlsYsDVoggDAuAjoK66k=
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f/go.mod h1:gcr0kNtGBqin9zDW9GOHcVntrwnjrK+qdJ06mWYBybw=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=


### PR DESCRIPTION
In GopenPGP v3, the verified data reader did not return a verification result if no verification keys were provided during decryption. This PR ensures that a verification result is returned even when no verification keys are provided. The verification result indicates that there were no matching verification keys.

Further updates go-crypto to `go-crypto v1.1.0-alpha.2`.