### PR TITLE
Add parsing and serializing interfaces for keyrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- API to serialize KeyRings to binary data:
+	```go
+	func (keyRing *KeyRing) Serialize() ([]byte, error)
+	```
+- API to parse KeyRings from binary data:
+	```go
+	func NewKeyRingFromBinary(binKeys []byte) (*KeyRing, error)
+	```
+
 ## [2.7.5] 2023-31-01
 
 ### Added

--- a/crypto/keyring.go
+++ b/crypto/keyring.go
@@ -64,8 +64,7 @@ func NewKeyRingFromBinary(binKeys []byte) (*KeyRing, error) {
 			return nil, errors.Wrap(err, "gopenpgp: error in reading keyring")
 		}
 
-		err = keyring.AddKey(key)
-		if err != nil {
+		if err = keyring.AddKey(key); err != nil {
 			return nil, errors.Wrap(err, "gopenpgp: error in reading keyring")
 		}
 	}

--- a/crypto/keyring_test.go
+++ b/crypto/keyring_test.go
@@ -148,6 +148,21 @@ func TestMultipleKeyRing(t *testing.T) {
 	assert.Exactly(t, 1, singleKeyRing.CountDecryptionEntities())
 }
 
+func TestSerializeParse(t *testing.T) {
+	serialized, err := keyRingTestMultiple.Serialize()
+	assert.Nil(t, err)
+
+	parsed, err := NewKeyRingFromBinary(serialized)
+	assert.Nil(t, err)
+
+	assert.Exactly(t, 3, len(parsed.GetKeys()))
+	for i, parsedKey := range parsed.GetKeys() {
+		expectedKey, err := keyRingTestMultiple.GetKey(i)
+		assert.Nil(t, err)
+		assert.Exactly(t, parsedKey.GetFingerprint(), expectedKey.GetFingerprint())
+	}
+}
+
 func TestClearPrivateKey(t *testing.T) {
 	keyRingCopy, err := keyRingTestMultiple.Copy()
 	if err != nil {


### PR DESCRIPTION
This PR adds an API to serialize KeyRings to binary data:
```go
func (keyRing *KeyRing) Serialize() ([]byte, error)
```
and an API to parse KeyRings from binary data:
```go
func NewKeyRingFromBinary(binKeys []byte) (*KeyRing, error)
```