### PR TITLE
Implement KeyRing.Armor()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- API to ASCII encode (armor) KeyRings:
+	```go
+	func (keyRing *KeyRing) Armor() (string, error)
+	```
+
 ## [2.8.0-alpha.1] 2024-04-09
 
 ### Added

--- a/crypto/keyring.go
+++ b/crypto/keyring.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/ProtonMail/gopenpgp/v2/armor"
+	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/pkg/errors"
 )
 
@@ -128,6 +130,16 @@ func (keyRing *KeyRing) Serialize() ([]byte, error) {
 	}
 
 	return buffer.Bytes(), nil
+}
+
+// Armor returns the armored keyring as a string with default gopenpgp headers.
+func (keyRing *KeyRing) Armor() (string, error) {
+	serialized, err := keyRing.Serialize()
+	if err != nil {
+		return "", err
+	}
+
+	return armor.ArmorWithType(serialized, constants.PublicKeyHeader)
 }
 
 // --- Extract info from key

--- a/crypto/keyring_test.go
+++ b/crypto/keyring_test.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"crypto/rsa"
 	"errors"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -161,6 +162,14 @@ func TestSerializeParse(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Exactly(t, parsedKey.GetFingerprint(), expectedKey.GetFingerprint())
 	}
+}
+
+func TestArmor(t *testing.T) {
+	armoredRing, err := keyRingTestMultiple.Armor()
+	assert.Nil(t, err)
+
+	rTest := regexp.MustCompile(`(?s)^-----BEGIN PGP PUBLIC KEY BLOCK-----.*Version: GopenPGP [0-9]+\.[0-9]+\.[0-9]+.*-----END PGP PUBLIC KEY BLOCK-----$`)
+	assert.Regexp(t, rTest, armoredRing)
 }
 
 func TestClearPrivateKey(t *testing.T) {


### PR DESCRIPTION
This allows for ASCII encoding of keyrings the same way as already implemented for individual keys.