### PR TITLE
 Armor checksum handling according to the crypto refresh

### DIFF
--- a/crypto/encrypt_decrypt_test.go
+++ b/crypto/encrypt_decrypt_test.go
@@ -923,6 +923,32 @@ func TestEncryptDecryptKey(t *testing.T) {
 	}
 }
 
+func TestEncryptDecryptStreamTrimmedLines(t *testing.T) {
+	for _, material := range testMaterialForProfiles {
+		t.Run(material.profileName, func(t *testing.T) {
+			encHandle, _ := material.pgp.Encryption().
+				Recipients(material.keyRingTestPublic).
+				SigningKeys(material.keyRingTestPrivate).
+				TrimLines().
+				New()
+			decHandle, _ := material.pgp.Decryption().
+				DecryptionKeys(material.keyRingTestPrivate).
+				VerificationKeys(material.keyRingTestPublic).
+				New()
+			testEncryptDecryptStreamWithExpected(
+				t,
+				[]byte("text with   \r \t \n trimmed\n   \t"),
+				[]byte("text with\n trimmed\n"),
+				nil,
+				encHandle,
+				decHandle,
+				len(material.keyRingTestPrivate.entities),
+				Bytes,
+			)
+		})
+	}
+}
+
 func TestEncryptCompressionApplied(t *testing.T) {
 	const numReplicas = 10
 	builder := strings.Builder{}
@@ -1140,6 +1166,28 @@ func testEncryptDecryptStream(
 	numberOfSigsToVerify int,
 	encoding int8,
 ) {
+	testEncryptDecryptStreamWithExpected(
+		t,
+		messageBytes,
+		messageBytes,
+		metadata,
+		encHandle,
+		decHandle,
+		numberOfSigsToVerify,
+		encoding,
+	)
+}
+
+func testEncryptDecryptStreamWithExpected(
+	t *testing.T,
+	messageBytes []byte,
+	expected []byte,
+	metadata *LiteralMetadata,
+	encHandle PGPEncryption,
+	decHandle PGPDecryption,
+	numberOfSigsToVerify int,
+	encoding int8,
+) {
 	messageReader := bytes.NewReader(messageBytes)
 	var ciphertextBuf bytes.Buffer
 	expectedMetadata := metadata
@@ -1170,7 +1218,7 @@ func testEncryptDecryptStream(
 	if err != nil {
 		t.Fatal("Expected no error while reading the decrypted data, got:", err)
 	}
-	if !bytes.Equal(decryptedBytes, messageBytes) {
+	if !bytes.Equal(decryptedBytes, expected) {
 		t.Fatalf("Expected the decrypted data to be %s got %s", string(decryptedBytes), string(messageBytes))
 	}
 	if numberOfSigsToVerify > 0 {

--- a/crypto/encryption_handle.go
+++ b/crypto/encryption_handle.go
@@ -55,6 +55,9 @@ type encryptionHandle struct {
 	// Is only considered if DetachedSignature is not set.
 	PlainDetachedSignature bool
 	IsUTF8                 bool
+	// TrimLines trims each end of the line in the input message before encryption.
+	// Remove trailing spaces, carriage returns and tabs from each line (separated by \n characters).
+	TrimLines bool
 	// ExternalSignature allows to include an external signature into
 	// the encrypted message.
 	ExternalSignature []byte
@@ -277,6 +280,9 @@ func (eh *encryptionHandle) encryptingWriters(keys, data, detachedSignature Writ
 		messageWriter = internal.NewUtf8CheckWriteCloser(
 			openpgp.NewCanonicalTextWriteCloser(messageWriter),
 		)
+	}
+	if eh.TrimLines {
+		messageWriter = internal.NewTrimWriteCloser(messageWriter)
 	}
 	return messageWriter, nil
 }

--- a/crypto/encryption_handle_builder.go
+++ b/crypto/encryption_handle_builder.go
@@ -148,6 +148,13 @@ func (ehb *EncryptionHandleBuilder) Utf8() *EncryptionHandleBuilder {
 	return ehb
 }
 
+// TrimLines enables that each line in the input message is trimmed before encryption.
+// Trim removes trailing spaces, carriage returns and tabs from each line (separated by \n characters).
+func (ehb *EncryptionHandleBuilder) TrimLines() *EncryptionHandleBuilder {
+	ehb.handle.TrimLines = true
+	return ehb
+}
+
 // DetachedSignature indicates that the message should be signed,
 // but the signature should not be included in the same pgp message as the input data.
 // Instead the detached signature is encrypted in a separate pgp message.

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -224,10 +224,10 @@ func (key *Key) Armor() (string, error) {
 	}
 
 	if key.IsPrivate() {
-		return armor.ArmorWithType(serialized, constants.PrivateKeyHeader)
+		return armor.ArmorWithTypeChecksum(serialized, constants.PrivateKeyHeader, !key.isVersion(6))
 	}
 
-	return armor.ArmorWithType(serialized, constants.PublicKeyHeader)
+	return armor.ArmorWithTypeChecksum(serialized, constants.PublicKeyHeader, !key.isVersion(6))
 }
 
 // ArmorWithCustomHeaders returns the armored key as a string, with
@@ -238,7 +238,7 @@ func (key *Key) ArmorWithCustomHeaders(comment, version string) (string, error) 
 		return "", err
 	}
 
-	return armor.ArmorWithTypeAndCustomHeaders(serialized, constants.PrivateKeyHeader, version, comment)
+	return armor.ArmorWithTypeAndCustomHeadersChecksum(serialized, constants.PrivateKeyHeader, version, comment, !key.isVersion(6))
 }
 
 // GetArmoredPublicKey returns the armored public keys from this keyring.
@@ -248,7 +248,7 @@ func (key *Key) GetArmoredPublicKey() (s string, err error) {
 		return "", err
 	}
 
-	return armor.ArmorWithType(serialized, constants.PublicKeyHeader)
+	return armor.ArmorWithTypeChecksum(serialized, constants.PublicKeyHeader, !key.isVersion(6))
 }
 
 // GetArmoredPublicKeyWithCustomHeaders returns the armored public key as a string, with
@@ -259,7 +259,7 @@ func (key *Key) GetArmoredPublicKeyWithCustomHeaders(comment, version string) (s
 		return "", err
 	}
 
-	return armor.ArmorWithTypeAndCustomHeaders(serialized, constants.PublicKeyHeader, version, comment)
+	return armor.ArmorWithTypeAndCustomHeadersChecksum(serialized, constants.PublicKeyHeader, version, comment, !key.isVersion(6))
 }
 
 // GetPublicKey returns the unarmored public keys from this keyring.
@@ -431,6 +431,13 @@ func (key *Key) ToPublic() (publicKey *Key, err error) {
 
 	publicKey.ClearPrivateParams()
 	return
+}
+
+func (key *Key) isVersion(version int) bool {
+	if key == nil || key.entity == nil {
+		return false
+	}
+	return key.entity.PrimaryKey.Version == version
 }
 
 // --- Internal methods

--- a/crypto/sign_handle.go
+++ b/crypto/sign_handle.go
@@ -16,10 +16,13 @@ import (
 )
 
 type signatureHandle struct {
-	SignKeyRing  *KeyRing
-	SignContext  *SigningContext
-	IsUTF8       bool
-	Detached     bool
+	SignKeyRing *KeyRing
+	SignContext *SigningContext
+	IsUTF8      bool
+	Detached    bool
+	// TrimLines trims each end of the line in the input message before encryption.
+	// Remove trailing spaces, carriage returns and tabs from each line (separated by \n characters).
+	TrimLines    bool
 	ArmorHeaders map[string]string
 	profile      SignProfile
 	clock        Clock
@@ -88,6 +91,9 @@ func (sh *signatureHandle) SigningWriter(outputWriter Writer, encoding int8) (me
 		messageWriter = internal.NewUtf8CheckWriteCloser(
 			openpgp.NewCanonicalTextWriteCloser(messageWriter),
 		)
+	}
+	if sh.TrimLines {
+		messageWriter = internal.NewTrimWriteCloser(messageWriter)
 	}
 	return messageWriter, nil
 }

--- a/crypto/sign_handle.go
+++ b/crypto/sign_handle.go
@@ -49,19 +49,17 @@ func (sh *signatureHandle) SigningWriter(outputWriter Writer, encoding int8) (me
 	var armorWriter WriteCloser
 	armorOutput := armorOutput(encoding)
 	if armorOutput {
+		doChecksum := sh.doArmorChecksum()
 		var err error
 		header := constants.PGPMessageHeader
 		if sh.Detached {
 			header = constants.PGPSignatureHeader
-			// Append checksum for GnuPG detached signature compatibility
-			armorWriter, err = armor.EncodeWithChecksumOption(outputWriter, header, sh.ArmorHeaders, true)
-		} else {
-			armorWriter, err = armor.EncodeWithChecksumOption(outputWriter, header, sh.ArmorHeaders, false)
 		}
-		outputWriter = armorWriter
+		armorWriter, err = armor.EncodeWithChecksumOption(outputWriter, header, sh.ArmorHeaders, doChecksum)
 		if err != nil {
 			return nil, err
 		}
+		outputWriter = armorWriter
 	}
 	if sh.Detached {
 		// Detached signature
@@ -137,6 +135,18 @@ func (sh *signatureHandle) validate() error {
 		return errors.New("gopenpgp: no signing key provided")
 	}
 	return nil
+}
+
+func (sh *signatureHandle) doArmorChecksum() bool {
+	if sh.SignKeyRing == nil {
+		return true
+	}
+	for _, signer := range sh.SignKeyRing.entities {
+		if signer.PrimaryKey.Version != 6 {
+			return true
+		}
+	}
+	return false
 }
 
 func (sh *signatureHandle) signCleartext(message []byte) ([]byte, error) {

--- a/crypto/sign_handle_builder.go
+++ b/crypto/sign_handle_builder.go
@@ -68,6 +68,13 @@ func (shb *SignHandleBuilder) Utf8() *SignHandleBuilder {
 	return shb
 }
 
+// TrimLines enables that each line in the input message is trimmed before encryption.
+// Trim removes trailing spaces, carriage returns and tabs from each line (separated by \n characters).
+func (shb *SignHandleBuilder) TrimLines() *SignHandleBuilder {
+	shb.handle.TrimLines = true
+	return shb
+}
+
 // SignTime sets the internal clock to always return
 // the supplied unix time for signing instead of the device time.
 func (shb *SignHandleBuilder) SignTime(unixTime int64) *SignHandleBuilder {

--- a/internal/trim_lines_writer.go
+++ b/internal/trim_lines_writer.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"bytes"
+	"io"
+)
+
+func trim(p []byte) []byte {
+	return bytes.TrimRight(p, " \t\r")
+}
+
+func NewTrimWriteCloser(internal io.WriteCloser) *TrimWriteCloser {
+	return NewTrimWriteCloserWithBufferSize(internal, 256)
+}
+
+func NewTrimWriteCloserWithBufferSize(internal io.WriteCloser, size int) *TrimWriteCloser {
+	return &TrimWriteCloser{
+		internal:   internal,
+		whitespace: bytes.NewBuffer(make([]byte, 0, size)),
+		err:        nil,
+	}
+}
+
+type TrimWriteCloser struct {
+	internal   io.WriteCloser
+	whitespace *bytes.Buffer
+	err        error
+}
+
+func (w *TrimWriteCloser) Write(p []byte) (n int, err error) {
+	n = len(p)
+	if w.err != nil {
+		return 0, err
+	}
+	for index := bytes.IndexByte(p, '\n'); index != -1; index = bytes.IndexByte(p, '\n') {
+		trimmedSuffixLine := trim(p[:index])
+		bufferWhitespace := w.whitespace.Bytes()
+		if len(bufferWhitespace) > 0 {
+			if len(trimmedSuffixLine) != 0 {
+				if _, err = w.internal.Write(bufferWhitespace); err != nil {
+					w.err = err
+					return 0, err
+				}
+			}
+			w.whitespace.Reset()
+		}
+		if len(trimmedSuffixLine) < len(p[:index]) {
+			if _, err = w.internal.Write(trimmedSuffixLine); err != nil {
+				w.err = err
+				return index, err
+			}
+			if _, err = w.internal.Write([]byte("\n")); err != nil {
+				w.err = err
+				return index + 1, err
+			}
+		} else {
+			if _, err = w.internal.Write(p[:index+1]); err != nil {
+				w.err = err
+				return index + 1, err
+			}
+		}
+		p = p[index+1:]
+	}
+
+	if len(p) > 0 {
+		nonWhitespace := trim(p)
+		if len(nonWhitespace) > 0 && w.whitespace.Len() > 0 {
+			if _, err = w.internal.Write(w.whitespace.Bytes()); err != nil {
+				w.err = err
+				return n - len(p), err
+			}
+			w.whitespace.Reset()
+		}
+		if _, err = w.internal.Write(nonWhitespace); err != nil {
+			w.err = err
+			return n - len(p), err
+		}
+
+		if _, err = w.whitespace.Write(p[len(nonWhitespace):]); err != nil {
+			w.err = err
+			return n - len(p), err
+		}
+	}
+	return n, nil
+}
+
+func (w *TrimWriteCloser) Close() error {
+	return w.internal.Close()
+}

--- a/internal/trim_lines_writer_test.go
+++ b/internal/trim_lines_writer_test.go
@@ -35,7 +35,7 @@ func testTrimWriteCloser(t *testing.T, test string) {
 func TestTrimWriteCloser(t *testing.T) {
 	testTrimWriteCloser(t, "\n    \t     \r")
 	testTrimWriteCloser(t, "this is a test \n   \t \n\n")
-	testTrimWriteCloser(t, "sdf\n   \t sdf\n \r\rsd   \t fsdf\n")
+	testTrimWriteCloser(t, "sdf\n   \t sddf\n \r\rsd   \t fsdf\n")
 	testTrimWriteCloser(t, "BEGIN:VCARD\r\nVERSION:4.0\r\nFN;PREF=1:   \r\nEND:VCARD")
 	testTrimWriteCloser(t, strings.Repeat("\r \nthis is a test \n   \t \n\n)", 10000))
 }

--- a/internal/trim_lines_writer_test.go
+++ b/internal/trim_lines_writer_test.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testTrimWriteCloser(t *testing.T, test string) {
+	testBytes := []byte(test)
+	for _, batchSize := range []int{1, 2, 3, 7, 11} {
+		var buff bytes.Buffer
+		w := &noOpWriteCloser{
+			writer: &buff,
+		}
+		trimWriter := NewTrimWriteCloser(w)
+		for ind := 0; ind < len(testBytes); ind += batchSize {
+			end := ind + batchSize
+			if end > len(testBytes) {
+				end = len(testBytes)
+			}
+			if _, err := trimWriter.Write(testBytes[ind:end]); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := trimWriter.Close(); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, TrimEachLine(test), buff.String())
+	}
+}
+
+func TestTrimWriteCloser(t *testing.T) {
+	testTrimWriteCloser(t, "\n    \t     \r")
+	testTrimWriteCloser(t, "this is a test \n   \t \n\n")
+	testTrimWriteCloser(t, "sdf\n   \t sdf\n \r\rsd   \t fsdf\n")
+	testTrimWriteCloser(t, "BEGIN:VCARD\r\nVERSION:4.0\r\nFN;PREF=1:   \r\nEND:VCARD")
+	testTrimWriteCloser(t, strings.Repeat("\r \nthis is a test \n   \t \n\n)", 10000))
+}

--- a/internal/utf8.go
+++ b/internal/utf8.go
@@ -164,19 +164,15 @@ func NewUtf8CheckWriteCloser(wrap io.WriteCloser) *Utf8CheckWriteCloser {
 }
 
 func (cw *Utf8CheckWriteCloser) Write(p []byte) (n int, err error) {
-	err = cw.check(p)
-	if err != nil {
-		return
+	if err = cw.check(p); err != nil {
+		return 0, err
 	}
-	n, err = cw.internal.Write(p)
-	return
+	return cw.internal.Write(p)
 }
 
 func (cw *Utf8CheckWriteCloser) Close() (err error) {
-	err = cw.close()
-	if err != nil {
-		return
+	if err = cw.close(); err != nil {
+		return err
 	}
-	err = cw.internal.Close()
-	return
+	return cw.internal.Close()
 }


### PR DESCRIPTION
GopenPGP v3 did not produce any armor checksum as recommended by the crypto refresh. Unfortunately, a popular OpenPGP library fails to parse armored messages without a checksum in certain scenarios.

This MR adds armor checksums back per default, but tries to avoid them when generating crypto refresh messages. i.e., generated by v6 keys. 

In GopenPGP v3, armor checksums were not produced, following recommendations from the OpenPGP crypto refresh. Unfortunately, a widely used OpenPGP library fails to parse armored messages that lack a checksum in certain scenarios although they should be optional according to the official RFC.

This merge request (MR) reinstates armor checksums by default to ensure compatibility. However, it tries to omit the checksums when generating messages for the crypto-refresh, i.e., those generated with v6 keys.

Changes:

- API to armor data with the option to remove the checksum 
- All armor functions append a checksum per default for compatibility with certain libraries although the crypto-refresh advises not to. 
- `Encryption` and `Sign` handle now append a checksum when armoring. If the produced OpenPGP packets are crypto-refresh packets, the checksum is not appended as mandated by the crypto-refresh.