### PR TITLE
v3: Rework Armor checksum handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- API to armor data with the option to remove the checksum 
+
+### Changed
+- All armor functions append a checksum per default for compatibility with certain libraries although the crypto-refresh advises not to. 
+- `Encryption` and `Sign` handle now append a checksum when armoring. If the produced OpenPGP packets are crypto-refresh packets, the checksum is not appended as mandated by the crypto-refresh.
+
 ## [3.0.0-alpha.2] 2024-04-12
 ### Added
 - API to serialize KeyRings to binary data:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ crypto library](https://github.com/ProtonMail/go-crypto/tree/version-2).
 <!-- TOC depthFrom:2 -->
 
 - [GopenPGP V3](#gopenpgp-v3)
+  - [GopenPGP V2 support](#gopenpgp-v2-support)
   - [Download/Install](#downloadinstall)
   - [Documentation](#documentation)
   - [Examples](#examples)
@@ -20,6 +21,14 @@ crypto library](https://github.com/ProtonMail/go-crypto/tree/version-2).
   - [Using with Go Mobile](#using-with-go-mobile)
 
 <!-- /TOC -->
+
+##  GopenPGP V2 support
+
+While GopenPGP V3 introduces a new API with significant enhancements, it is not backward compatible with GopenPGP V2. 
+Although we recommend upgrading to V3 for the latest features and improvements, we continue to support GopenPGP V2. 
+Our support includes ongoing bug fixes and minor feature updates to ensure stability and functionality for existing users.
+
+You can access GopenPGP V2 on the [v2 branch of this repository](https://github.com/ProtonMail/gopenpgp/tree/v2).
 
 ## Download/Install
 

--- a/armor/armor.go
+++ b/armor/armor.go
@@ -20,7 +20,7 @@ func ArmorKey(input []byte) (string, error) {
 // ArmorWriterWithType returns a io.WriteCloser which, when written to, writes
 // armored data to w with the given armorType.
 func ArmorWriterWithType(w io.Writer, armorType string) (io.WriteCloser, error) {
-	return armor.EncodeWithChecksumOption(w, armorType, internal.ArmorHeaders, constants.DoChecksum)
+	return armor.EncodeWithChecksumOption(w, armorType, internal.ArmorHeaders, constants.ArmorChecksumSetting)
 }
 
 // ArmorWriterWithTypeChecksum returns a io.WriteCloser which, when written to, writes
@@ -40,12 +40,12 @@ func ArmorWriterWithTypeAndCustomHeaders(w io.Writer, armorType, version, commen
 	if comment != "" {
 		headers["Comment"] = comment
 	}
-	return armor.EncodeWithChecksumOption(w, armorType, headers, constants.DoChecksum)
+	return armor.EncodeWithChecksumOption(w, armorType, headers, constants.ArmorChecksumSetting)
 }
 
 // ArmorWithType armors input with the given armorType.
 func ArmorWithType(input []byte, armorType string) (string, error) {
-	return ArmorWithTypeChecksum(input, armorType, constants.DoChecksum)
+	return ArmorWithTypeChecksum(input, armorType, constants.ArmorChecksumSetting)
 }
 
 // ArmorWithTypeChecksum armors input with the given armorType.
@@ -60,7 +60,7 @@ func ArmorWithTypeChecksum(input []byte, armorType string, checksum bool) (strin
 
 // ArmorWithTypeBytes armors input with the given armorType.
 func ArmorWithTypeBytes(input []byte, armorType string) ([]byte, error) {
-	return ArmorWithTypeBytesChecksum(input, armorType, constants.DoChecksum)
+	return ArmorWithTypeBytesChecksum(input, armorType, constants.ArmorChecksumSetting)
 }
 
 // ArmorWithTypeBytesChecksum armors input with the given armorType and checksum option.
@@ -75,7 +75,7 @@ func ArmorWithTypeBytesChecksum(input []byte, armorType string, checksum bool) (
 // ArmorWithTypeAndCustomHeaders armors input with the given armorType and
 // headers.
 func ArmorWithTypeAndCustomHeaders(input []byte, armorType, version, comment string) (string, error) {
-	return ArmorWithTypeAndCustomHeadersChecksum(input, armorType, version, comment, constants.DoChecksum)
+	return ArmorWithTypeAndCustomHeadersChecksum(input, armorType, version, comment, constants.ArmorChecksumSetting)
 }
 
 // ArmorWithTypeAndCustomHeadersChecksum armors input with the given armorType and
@@ -105,7 +105,7 @@ func ArmorWithTypeAndCustomHeadersBytes(input []byte, armorType, version, commen
 	if comment != "" {
 		headers["Comment"] = comment
 	}
-	buffer, err := armorWithTypeAndHeaders(input, armorType, headers, constants.DoChecksum)
+	buffer, err := armorWithTypeAndHeaders(input, armorType, headers, constants.ArmorChecksumSetting)
 	if err != nil {
 		return nil, err
 	}
@@ -182,10 +182,10 @@ func IsPGPArmored(in io.Reader) (io.Reader, bool) {
 	return outReader, false
 }
 
-func armorWithTypeAndHeaders(input []byte, armorType string, headers map[string]string, doChecksum bool) (*bytes.Buffer, error) {
+func armorWithTypeAndHeaders(input []byte, armorType string, headers map[string]string, writeChecksum bool) (*bytes.Buffer, error) {
 	var b bytes.Buffer
 
-	w, err := armor.EncodeWithChecksumOption(&b, armorType, headers, doChecksum)
+	w, err := armor.EncodeWithChecksumOption(&b, armorType, headers, writeChecksum)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "armor: unable to encode armoring")

--- a/armor/armor.go
+++ b/armor/armor.go
@@ -20,7 +20,7 @@ func ArmorKey(input []byte) (string, error) {
 // ArmorWriterWithType returns a io.WriteCloser which, when written to, writes
 // armored data to w with the given armorType.
 func ArmorWriterWithType(w io.Writer, armorType string) (io.WriteCloser, error) {
-	return armor.EncodeWithChecksumOption(w, armorType, internal.ArmorHeaders, constants.ArmorChecksumSetting)
+	return armor.EncodeWithChecksumOption(w, armorType, internal.ArmorHeaders, constants.ArmorChecksumEnabled)
 }
 
 // ArmorWriterWithTypeChecksum returns a io.WriteCloser which, when written to, writes
@@ -40,12 +40,12 @@ func ArmorWriterWithTypeAndCustomHeaders(w io.Writer, armorType, version, commen
 	if comment != "" {
 		headers["Comment"] = comment
 	}
-	return armor.EncodeWithChecksumOption(w, armorType, headers, constants.ArmorChecksumSetting)
+	return armor.EncodeWithChecksumOption(w, armorType, headers, constants.ArmorChecksumEnabled)
 }
 
 // ArmorWithType armors input with the given armorType.
 func ArmorWithType(input []byte, armorType string) (string, error) {
-	return ArmorWithTypeChecksum(input, armorType, constants.ArmorChecksumSetting)
+	return ArmorWithTypeChecksum(input, armorType, constants.ArmorChecksumEnabled)
 }
 
 // ArmorWithTypeChecksum armors input with the given armorType.
@@ -60,7 +60,7 @@ func ArmorWithTypeChecksum(input []byte, armorType string, checksum bool) (strin
 
 // ArmorWithTypeBytes armors input with the given armorType.
 func ArmorWithTypeBytes(input []byte, armorType string) ([]byte, error) {
-	return ArmorWithTypeBytesChecksum(input, armorType, constants.ArmorChecksumSetting)
+	return ArmorWithTypeBytesChecksum(input, armorType, constants.ArmorChecksumEnabled)
 }
 
 // ArmorWithTypeBytesChecksum armors input with the given armorType and checksum option.
@@ -75,7 +75,7 @@ func ArmorWithTypeBytesChecksum(input []byte, armorType string, checksum bool) (
 // ArmorWithTypeAndCustomHeaders armors input with the given armorType and
 // headers.
 func ArmorWithTypeAndCustomHeaders(input []byte, armorType, version, comment string) (string, error) {
-	return ArmorWithTypeAndCustomHeadersChecksum(input, armorType, version, comment, constants.ArmorChecksumSetting)
+	return ArmorWithTypeAndCustomHeadersChecksum(input, armorType, version, comment, constants.ArmorChecksumEnabled)
 }
 
 // ArmorWithTypeAndCustomHeadersChecksum armors input with the given armorType and
@@ -105,7 +105,7 @@ func ArmorWithTypeAndCustomHeadersBytes(input []byte, armorType, version, commen
 	if comment != "" {
 		headers["Comment"] = comment
 	}
-	buffer, err := armorWithTypeAndHeaders(input, armorType, headers, constants.ArmorChecksumSetting)
+	buffer, err := armorWithTypeAndHeaders(input, armorType, headers, constants.ArmorChecksumEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,6 +3,7 @@ package constants
 
 // Constants for armored data.
 const (
+	DoChecksum         = true
 	ArmorHeaderEnabled = false // can be enabled for debugging at compile time only
 	ArmorHeaderVersion = "GopenPGP " + Version
 	ArmorHeaderComment = "https://gopenpgp.org"

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,12 +3,18 @@ package constants
 
 // Constants for armored data.
 const (
-	DoChecksum         = true
-	ArmorHeaderEnabled = false // can be enabled for debugging at compile time only
-	ArmorHeaderVersion = "GopenPGP " + Version
-	ArmorHeaderComment = "https://gopenpgp.org"
-	PGPMessageHeader   = "PGP MESSAGE"
-	PGPSignatureHeader = "PGP SIGNATURE"
-	PublicKeyHeader    = "PGP PUBLIC KEY BLOCK"
-	PrivateKeyHeader   = "PGP PRIVATE KEY BLOCK"
+	// ArmorChecksumSetting defines the default behavior for adding an armor checksum
+	// to an armored message.
+	//
+	// If set to true, an armor checksum is added to the message.
+	//
+	// If set to false, no armor checksum is added.
+	ArmorChecksumSetting = true
+	ArmorHeaderEnabled   = false // can be enabled for debugging at compile time only
+	ArmorHeaderVersion   = "GopenPGP " + Version
+	ArmorHeaderComment   = "https://gopenpgp.org"
+	PGPMessageHeader     = "PGP MESSAGE"
+	PGPSignatureHeader   = "PGP SIGNATURE"
+	PublicKeyHeader      = "PGP PUBLIC KEY BLOCK"
+	PrivateKeyHeader     = "PGP PRIVATE KEY BLOCK"
 )

--- a/constants/armor.go
+++ b/constants/armor.go
@@ -3,13 +3,13 @@ package constants
 
 // Constants for armored data.
 const (
-	// ArmorChecksumSetting defines the default behavior for adding an armor checksum
+	// ArmorChecksumEnabled defines the default behavior for adding an armor checksum
 	// to an armored message.
 	//
 	// If set to true, an armor checksum is added to the message.
 	//
 	// If set to false, no armor checksum is added.
-	ArmorChecksumSetting = true
+	ArmorChecksumEnabled = true
 	ArmorHeaderEnabled   = false // can be enabled for debugging at compile time only
 	ArmorHeaderVersion   = "GopenPGP " + Version
 	ArmorHeaderComment   = "https://gopenpgp.org"

--- a/crypto/encrypt_decrypt_test.go
+++ b/crypto/encrypt_decrypt_test.go
@@ -1010,7 +1010,7 @@ func TestEncryptDecryptPlaintextDetachedArmor(t *testing.T) {
 func TestEncryptArmor(t *testing.T) {
 	for _, material := range testMaterialForProfiles {
 		t.Run(material.profileName, func(t *testing.T) {
-			isV6 := material.keyRingTestPublic.GetKeys()[0].isVersionSix()
+			isV6 := material.keyRingTestPublic.GetKeys()[0].isV6()
 			encHandle, _ := material.pgp.Encryption().
 				Recipients(material.keyRingTestPublic).
 				SigningKeys(material.keyRingTestPrivate).

--- a/crypto/encrypt_decrypt_test.go
+++ b/crypto/encrypt_decrypt_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -1004,6 +1005,35 @@ func TestEncryptDecryptPlaintextDetachedArmor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEncryptArmor(t *testing.T) {
+	for _, material := range testMaterialForProfiles {
+		t.Run(material.profileName, func(t *testing.T) {
+			isV6 := material.keyRingTestPublic.GetKeys()[0].isVersionSix()
+			encHandle, _ := material.pgp.Encryption().
+				Recipients(material.keyRingTestPublic).
+				SigningKeys(material.keyRingTestPrivate).
+				New()
+			pgpMsg, err := encHandle.Encrypt([]byte(testMessageString))
+			if err != nil {
+				t.Fatal("Expected no error in encryption, got:", err)
+			}
+			armoredData, err := pgpMsg.Armor()
+			if err != nil {
+				t.Fatal("Armoring failed, got:", err)
+			}
+			hasChecksum := containsChecksum(armoredData)
+			if isV6 && hasChecksum {
+				t.Fatalf("V6 messages should not have a checksum")
+			}
+		})
+	}
+}
+
+func containsChecksum(armored string) bool {
+	re := regexp.MustCompile(`=([A-Za-z0-9+/]{4})\s*-----END PGP MESSAGE-----`)
+	return re.MatchString(armored)
 }
 
 func testEncryptDecrypt(

--- a/crypto/encryption_handle.go
+++ b/crypto/encryption_handle.go
@@ -154,7 +154,7 @@ func (eh *encryptionHandle) validate() error {
 // armorChecksumRequired determines if an armor checksum should be appended or not.
 // The OpenPGP Crypto-Refresh mandates that no checksum should be appended with the new packets.
 func (eh *encryptionHandle) armorChecksumRequired() bool {
-	if !constants.ArmorChecksumSetting {
+	if !constants.ArmorChecksumEnabled {
 		// If the default behavior is no checksum, we can ignore
 		// the logic for the crypto refresh check.
 		return false

--- a/crypto/encryption_handle.go
+++ b/crypto/encryption_handle.go
@@ -109,7 +109,8 @@ func (eh *encryptionHandle) Encrypt(message []byte) (*PGPMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return pgpMessageBuffer.PGPMessageWithDetached(eh.PlainDetachedSignature), nil
+	checksum := eh.doArmorChecksum()
+	return pgpMessageBuffer.PGPMessageWithOptions(eh.PlainDetachedSignature, !checksum), nil
 }
 
 // EncryptSessionKey encrypts a session key with the encryption handle.
@@ -150,6 +151,39 @@ func (eh *encryptionHandle) validate() error {
 	return nil
 }
 
+// doArmorChecksum determines if an armor checksum should be appended or not.
+// The OpenPGP Crypto-Refresh mandates that no checksum should be appended with the new packets.
+func (eh *encryptionHandle) doArmorChecksum() bool {
+	encryptionConfig := eh.profile.EncryptionConfig()
+	if encryptionConfig.AEADConfig == nil {
+		return constants.DoChecksum
+	}
+	checkTime := eh.clock()
+	if eh.Recipients != nil {
+		for _, recipient := range eh.Recipients.entities {
+			primarySelfSignature, err := recipient.PrimarySelfSignature(checkTime)
+			if err != nil {
+				return constants.DoChecksum
+			}
+			if !primarySelfSignature.SEIPDv2 {
+				return constants.DoChecksum
+			}
+		}
+	}
+	if eh.HiddenRecipients != nil {
+		for _, recipient := range eh.HiddenRecipients.entities {
+			primarySelfSignature, err := recipient.PrimarySelfSignature(checkTime)
+			if err != nil {
+				return constants.DoChecksum
+			}
+			if !primarySelfSignature.SEIPDv2 {
+				return constants.DoChecksum
+			}
+		}
+	}
+	return false
+}
+
 type armoredWriteCloser struct {
 	armorWriter    WriteCloser
 	messageWriter  WriteCloser
@@ -185,11 +219,47 @@ func (eh *encryptionHandle) ClearPrivateParams() {
 	}
 }
 
+func (eh *encryptionHandle) handleArmor(keys, data, detachedSignature Writer) (
+	dataOut Writer,
+	detachedSignatureOut Writer,
+	armorWriter WriteCloser,
+	armorSigWriter WriteCloser,
+	err error,
+) {
+	doChecksum := eh.doArmorChecksum()
+	detachedSignatureOut = detachedSignature
+	// Wrap armored writer
+	if eh.ArmorHeaders == nil {
+		eh.ArmorHeaders = internal.ArmorHeaders
+	}
+	armorWriter, err = armor.EncodeWithChecksumOption(data, constants.PGPMessageHeader, eh.ArmorHeaders, doChecksum)
+	dataOut = armorWriter
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if eh.DetachedSignature {
+		armorSigWriter, err = armor.EncodeWithChecksumOption(detachedSignature, constants.PGPMessageHeader, eh.ArmorHeaders, doChecksum)
+		detachedSignatureOut = armorSigWriter
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+	} else if eh.PlainDetachedSignature {
+		armorSigWriter, err = armor.EncodeWithChecksumOption(detachedSignature, constants.PGPSignatureHeader, eh.ArmorHeaders, doChecksum)
+		detachedSignatureOut = armorSigWriter
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+	}
+	if keys != nil {
+		return nil, nil, nil, nil, errors.New("gopenpgp: armor is not allowed if key packets are written separately")
+	}
+	return dataOut, detachedSignatureOut, armorWriter, armorSigWriter, nil
+}
+
 func (eh *encryptionHandle) encryptingWriters(keys, data, detachedSignature Writer, meta *LiteralMetadata, armorOutput bool) (messageWriter WriteCloser, err error) {
 	var armorWriter WriteCloser
 	var armorSigWriter WriteCloser
-	err = eh.validate()
-	if err != nil {
+	if err = eh.validate(); err != nil {
 		return nil, err
 	}
 
@@ -199,30 +269,9 @@ func (eh *encryptionHandle) encryptingWriters(keys, data, detachedSignature Writ
 	}
 
 	if armorOutput {
-		// Wrap armored writer
-		if eh.ArmorHeaders == nil {
-			eh.ArmorHeaders = internal.ArmorHeaders
-		}
-		armorWriter, err = armor.EncodeWithChecksumOption(data, constants.PGPMessageHeader, eh.ArmorHeaders, false)
-		data = armorWriter
+		data, detachedSignature, armorWriter, armorSigWriter, err = eh.handleArmor(keys, data, detachedSignature)
 		if err != nil {
 			return nil, err
-		}
-		if eh.DetachedSignature {
-			armorSigWriter, err = armor.EncodeWithChecksumOption(detachedSignature, constants.PGPMessageHeader, eh.ArmorHeaders, false)
-			detachedSignature = armorSigWriter
-			if err != nil {
-				return nil, err
-			}
-		} else if eh.PlainDetachedSignature {
-			armorSigWriter, err = armor.EncodeWithChecksumOption(detachedSignature, constants.PGPSignatureHeader, eh.ArmorHeaders, false)
-			detachedSignature = armorSigWriter
-			if err != nil {
-				return nil, err
-			}
-		}
-		if keys != nil {
-			return nil, errors.New("gopenpgp: armor is not allowed if key packets are written separately")
 		}
 	}
 	if keys == nil {

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -224,10 +224,10 @@ func (key *Key) Armor() (string, error) {
 	}
 
 	if key.IsPrivate() {
-		return armor.ArmorWithType(serialized, constants.PrivateKeyHeader)
+		return armor.ArmorWithTypeChecksum(serialized, constants.PrivateKeyHeader, !key.isVersionSix())
 	}
 
-	return armor.ArmorWithType(serialized, constants.PublicKeyHeader)
+	return armor.ArmorWithTypeChecksum(serialized, constants.PublicKeyHeader, !key.isVersionSix())
 }
 
 // ArmorWithCustomHeaders returns the armored key as a string, with
@@ -238,7 +238,7 @@ func (key *Key) ArmorWithCustomHeaders(comment, version string) (string, error) 
 		return "", err
 	}
 
-	return armor.ArmorWithTypeAndCustomHeaders(serialized, constants.PrivateKeyHeader, version, comment)
+	return armor.ArmorWithTypeAndCustomHeadersChecksum(serialized, constants.PrivateKeyHeader, version, comment, !key.isVersionSix())
 }
 
 // GetArmoredPublicKey returns the armored public keys from this keyring.
@@ -248,7 +248,7 @@ func (key *Key) GetArmoredPublicKey() (s string, err error) {
 		return "", err
 	}
 
-	return armor.ArmorWithType(serialized, constants.PublicKeyHeader)
+	return armor.ArmorWithTypeChecksum(serialized, constants.PublicKeyHeader, !key.isVersionSix())
 }
 
 // GetArmoredPublicKeyWithCustomHeaders returns the armored public key as a string, with
@@ -259,7 +259,7 @@ func (key *Key) GetArmoredPublicKeyWithCustomHeaders(comment, version string) (s
 		return "", err
 	}
 
-	return armor.ArmorWithTypeAndCustomHeaders(serialized, constants.PublicKeyHeader, version, comment)
+	return armor.ArmorWithTypeAndCustomHeadersChecksum(serialized, constants.PublicKeyHeader, version, comment, !key.isVersionSix())
 }
 
 // GetPublicKey returns the unarmored public keys from this keyring.
@@ -431,6 +431,13 @@ func (key *Key) ToPublic() (publicKey *Key, err error) {
 
 	publicKey.ClearPrivateParams()
 	return
+}
+
+func (key *Key) isVersionSix() bool {
+	if key == nil || key.entity == nil {
+		return false
+	}
+	return key.entity.PrimaryKey.Version == 6
 }
 
 // --- Internal methods

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -224,10 +224,10 @@ func (key *Key) Armor() (string, error) {
 	}
 
 	if key.IsPrivate() {
-		return armor.ArmorWithTypeChecksum(serialized, constants.PrivateKeyHeader, !key.isVersionSix())
+		return armor.ArmorWithTypeChecksum(serialized, constants.PrivateKeyHeader, !key.isV6())
 	}
 
-	return armor.ArmorWithTypeChecksum(serialized, constants.PublicKeyHeader, !key.isVersionSix())
+	return armor.ArmorWithTypeChecksum(serialized, constants.PublicKeyHeader, !key.isV6())
 }
 
 // ArmorWithCustomHeaders returns the armored key as a string, with
@@ -238,7 +238,7 @@ func (key *Key) ArmorWithCustomHeaders(comment, version string) (string, error) 
 		return "", err
 	}
 
-	return armor.ArmorWithTypeAndCustomHeadersChecksum(serialized, constants.PrivateKeyHeader, version, comment, !key.isVersionSix())
+	return armor.ArmorWithTypeAndCustomHeadersChecksum(serialized, constants.PrivateKeyHeader, version, comment, !key.isV6())
 }
 
 // GetArmoredPublicKey returns the armored public keys from this keyring.
@@ -248,7 +248,7 @@ func (key *Key) GetArmoredPublicKey() (s string, err error) {
 		return "", err
 	}
 
-	return armor.ArmorWithTypeChecksum(serialized, constants.PublicKeyHeader, !key.isVersionSix())
+	return armor.ArmorWithTypeChecksum(serialized, constants.PublicKeyHeader, !key.isV6())
 }
 
 // GetArmoredPublicKeyWithCustomHeaders returns the armored public key as a string, with
@@ -259,7 +259,7 @@ func (key *Key) GetArmoredPublicKeyWithCustomHeaders(comment, version string) (s
 		return "", err
 	}
 
-	return armor.ArmorWithTypeAndCustomHeadersChecksum(serialized, constants.PublicKeyHeader, version, comment, !key.isVersionSix())
+	return armor.ArmorWithTypeAndCustomHeadersChecksum(serialized, constants.PublicKeyHeader, version, comment, !key.isV6())
 }
 
 // GetPublicKey returns the unarmored public keys from this keyring.
@@ -433,7 +433,7 @@ func (key *Key) ToPublic() (publicKey *Key, err error) {
 	return
 }
 
-func (key *Key) isVersionSix() bool {
+func (key *Key) isV6() bool {
 	if key == nil || key.entity == nil {
 		return false
 	}

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -37,7 +37,7 @@ type PGPMessage struct {
 	// detachedSignatureIsPlain indicates if the detached signature is not encrypted.
 	detachedSignatureIsPlain bool
 	// Signals that no armor checksum must be appended when armoring
-	forceNoArmorChecksum bool
+	omitArmorChecksum bool
 }
 
 type PGPMessageBuffer struct {
@@ -141,7 +141,7 @@ func (msg *PGPMessage) Armor() (string, error) {
 	if msg.KeyPacket == nil {
 		return "", errors.New("gopenpgp: missing key packets in pgp message")
 	}
-	if msg.forceNoArmorChecksum {
+	if msg.omitArmorChecksum {
 		return armor.ArmorPGPMessageChecksum(msg.Bytes(), false)
 	}
 	return armor.ArmorPGPMessage(msg.Bytes())
@@ -152,7 +152,7 @@ func (msg *PGPMessage) ArmorBytes() ([]byte, error) {
 	if msg.KeyPacket == nil {
 		return nil, errors.New("gopenpgp: missing key packets in pgp message")
 	}
-	if msg.forceNoArmorChecksum {
+	if msg.omitArmorChecksum {
 		return armor.ArmorPGPMessageBytesChecksum(msg.Bytes(), false)
 	}
 	return armor.ArmorPGPMessageBytes(msg.Bytes())
@@ -161,7 +161,7 @@ func (msg *PGPMessage) ArmorBytes() ([]byte, error) {
 // ArmorWithCustomHeaders returns the armored message as a string, with
 // the given headers. Empty parameters are omitted from the headers.
 func (msg *PGPMessage) ArmorWithCustomHeaders(comment, version string) (string, error) {
-	if msg.forceNoArmorChecksum {
+	if msg.omitArmorChecksum {
 		return armor.ArmorWithTypeAndCustomHeadersChecksum(msg.Bytes(), constants.PGPMessageHeader, version, comment, false)
 	}
 	return armor.ArmorWithTypeAndCustomHeaders(msg.Bytes(), constants.PGPMessageHeader, version, comment)
@@ -371,7 +371,7 @@ func (mb *PGPMessageBuffer) PGPMessage() *PGPMessage {
 
 // PGPMessageWithOptions returns the PGPMessage extracted from the internal buffers.
 // The isPlain flag indicates wether the detached signature is encrypted or plaintext, if any.
-func (mb *PGPMessageBuffer) PGPMessageWithOptions(isPlain, forceNoChecksum bool) *PGPMessage {
+func (mb *PGPMessageBuffer) PGPMessageWithOptions(isPlain, omitArmorChecksum bool) *PGPMessage {
 	var detachedSignature []byte
 	if mb.signature.Len() > 0 {
 		detachedSignature = mb.signature.Bytes()
@@ -386,7 +386,7 @@ func (mb *PGPMessageBuffer) PGPMessageWithOptions(isPlain, forceNoChecksum bool)
 		DataPacket:               mb.data.Bytes(),
 		DetachedSignature:        detachedSignature,
 		detachedSignatureIsPlain: isPlain,
-		forceNoArmorChecksum:     forceNoChecksum,
+		omitArmorChecksum:        omitArmorChecksum,
 	}
 }
 

--- a/crypto/sign_handle.go
+++ b/crypto/sign_handle.go
@@ -132,7 +132,7 @@ func (sh *signatureHandle) validate() error {
 }
 
 func (sh *signatureHandle) armorChecksumRequired() bool {
-	if !constants.ArmorChecksumSetting {
+	if !constants.ArmorChecksumEnabled {
 		// If the default behavior is no checksum, we can ignore
 		// the logic for the crypto refresh check.
 		return false

--- a/crypto/sign_verify_test.go
+++ b/crypto/sign_verify_test.go
@@ -178,6 +178,25 @@ func TestSignVerifyCleartext(t *testing.T) {
 	}
 }
 
+func TestSignArmor(t *testing.T) {
+	for _, material := range testMaterialForProfiles {
+		t.Run(material.profileName, func(t *testing.T) {
+			isV6 := material.keyRingTestPrivate.GetKeys()[0].isVersionSix()
+			signer, _ := material.pgp.Sign().
+				SigningKeys(material.keyRingTestPrivate).
+				New()
+			armoredSignature, err := signer.Sign([]byte(testMessageString), Armor)
+			if err != nil {
+				t.Fatal("Expected no error in singing, got:", err)
+			}
+			hasChecksum := containsChecksum(string(armoredSignature))
+			if isV6 && hasChecksum {
+				t.Fatalf("V6 messages should not have a checksum")
+			}
+		})
+	}
+}
+
 func testSignVerify(
 	t *testing.T,
 	signer PGPSign,

--- a/crypto/sign_verify_test.go
+++ b/crypto/sign_verify_test.go
@@ -181,7 +181,7 @@ func TestSignVerifyCleartext(t *testing.T) {
 func TestSignArmor(t *testing.T) {
 	for _, material := range testMaterialForProfiles {
 		t.Run(material.profileName, func(t *testing.T) {
-			isV6 := material.keyRingTestPrivate.GetKeys()[0].isVersionSix()
+			isV6 := material.keyRingTestPrivate.GetKeys()[0].isV6()
 			signer, _ := material.pgp.Sign().
 				SigningKeys(material.keyRingTestPrivate).
 				New()


### PR DESCRIPTION
GopenPGP v3 did not produce any armor checksum as recommended by the crypto refresh. Unfortunately, a popular OpenPGP library fails to parse armored messages without a checksum in certain scenarios.

This MR adds armor checksums back per default, but tries to avoid them when generating crypto refresh messages. i.e., generated by v6 keys.

In GopenPGP v3, armor checksums were not produced, following recommendations from the OpenPGP crypto refresh. Unfortunately, a widely used OpenPGP library fails to parse armored messages that lack a checksum in certain scenarios although they should be optional according to the official RFC.

This merge request (MR) reinstates armor checksums by default to ensure compatibility. However, it tries to omit the checksums when generating messages for the crypto-refresh, i.e., those generated with v6 keys.

Changes:

- API to armor data with the option to remove the checksum
- All armor functions append a checksum per default for compatibility with certain libraries although the crypto-refresh advises not to.
- Encryption and Sign handle now append a checksum when armoring. If the produced OpenPGP packets are crypto-refresh packets, the checksum is not appended as mandated by the crypto-refresh.