### PR TITLE
ci: Update github workflow actions

### DIFF
--- a/.github/actions/build-gosop/action.yml
+++ b/.github/actions/build-gosop/action.yml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout gopenpgp
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.gopenpgp-ref }}
         path: gopenpgp
@@ -32,7 +32,7 @@ runs:
       with:
         go-version: ^1.18
     - name: Check out gosop
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ProtonMail/gosop
         ref: ${{ env.GOSOP_BRANCH_REF}}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,7 +30,7 @@ jobs:
         link-to-sdk: true
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build
       run: |
@@ -41,7 +41,7 @@ jobs:
         find dist
 
     - name: Upload Android artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Android build
         path: dist/android

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up latest golang
         uses: actions/setup-go@v3
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Go 1.17
       uses: actions/setup-go@v3
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.17
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -25,7 +25,7 @@ jobs:
         id: go
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
         env:
@@ -35,7 +35,7 @@ jobs:
           find dist
 
       - name: Upload xcframework
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: gopenpgp.xcframework
           path: dist/apple/gopenpgp.xcframework

--- a/.github/workflows/sop-test-suite.yml
+++ b/.github/workflows/sop-test-suite.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build gosop from branch
         uses: ./.github/actions/build-gosop
         with: 
           binary-location: ./gosop-${{ github.sha }}
       # Upload as artifact
       - name: Upload gosop artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gosop-${{ github.sha }}
           path: ./gosop-${{ github.sha }}
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build gosop from branch
         uses: ./.github/actions/build-gosop
         with: 
@@ -36,7 +36,7 @@ jobs:
           binary-location: ./gosop-target
       # Upload as artifact
       - name: Upload gosop-target artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gosop-target
           path: ./gosop-target
@@ -55,7 +55,7 @@ jobs:
       - build-gosop-target
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Fetch gosop from target
       - name: Download gosop-target
         uses: actions/download-artifact@v3
@@ -94,12 +94,12 @@ jobs:
          RESULTS_HTML: .github/test-suite/test-suite-results.html
       # Upload results
       - name: Upload test results json artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-suite-results.json
           path: .github/test-suite/test-suite-results.json
       - name: Upload test results html artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-suite-results.html
           path: .github/test-suite/test-suite-results.html
@@ -110,7 +110,7 @@ jobs:
     needs: test-suite
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download test results json artifact
         id: download-test-results
         uses: actions/download-artifact@v3

--- a/.github/workflows/sop-test-suite.yml
+++ b/.github/workflows/sop-test-suite.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
       # Fetch gosop from target
       - name: Download gosop-target
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gosop-target
       # Test gosop-target
@@ -68,7 +68,7 @@ jobs:
         run: ./gosop-target version --extended
       # Fetch gosop from branch
       - name: Download gosop-branch
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gosop-${{ github.sha }}
       - name: Rename gosop-branch
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Download test results json artifact
         id: download-test-results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-suite-results.json
       - name: Compare with baseline


### PR DESCRIPTION
The CI is currently broken due to action deprications.
Fix:
- update actions/download-artifact to v4
- update actions/checkout to v4
- update actions/upload-artifact to v4