### PR TITLE
Remove signature rejection logic based on hash

### DIFF
--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -2,7 +2,6 @@ package crypto
 
 import (
 	"bytes"
-	"crypto"
 	"fmt"
 	"time"
 
@@ -13,13 +12,6 @@ import (
 
 	"github.com/ProtonMail/gopenpgp/v3/constants"
 )
-
-var allowedHashesSet = map[crypto.Hash]struct{}{
-	crypto.SHA224: {},
-	crypto.SHA256: {},
-	crypto.SHA384: {},
-	crypto.SHA512: {},
-}
 
 // VerifiedSignature is a result of a signature verification.
 type VerifiedSignature struct {
@@ -305,7 +297,7 @@ func createVerifyResult(
 			signatureError = newSignatureNoVerifier()
 		case signature.SignatureError != nil:
 			signatureError = newSignatureFailed(signature.SignatureError)
-		case signature.CorrespondingSig == nil || !isHashAllowed(signature.CorrespondingSig.Hash):
+		case signature.CorrespondingSig == nil:
 			signatureError = newSignatureInsecure()
 		case verificationContext != nil:
 			err := verificationContext.verifyContext(signature.CorrespondingSig)
@@ -408,9 +400,4 @@ func (context *VerificationContext) verifyContext(sig *packet.Signature) error {
 	}
 
 	return nil
-}
-
-func isHashAllowed(h crypto.Hash) bool {
-	_, ok := allowedHashesSet[h]
-	return ok
 }

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -297,8 +297,6 @@ func createVerifyResult(
 			signatureError = newSignatureNoVerifier()
 		case signature.SignatureError != nil:
 			signatureError = newSignatureFailed(signature.SignatureError)
-		case signature.CorrespondingSig == nil:
-			signatureError = newSignatureInsecure()
 		case verificationContext != nil:
 			err := verificationContext.verifyContext(signature.CorrespondingSig)
 			if err != nil {
@@ -386,6 +384,9 @@ func findContext(notations []*packet.Notation) (string, error) {
 }
 
 func (context *VerificationContext) verifyContext(sig *packet.Signature) error {
+	if sig == nil {
+		return errors.New("gopenpgp: no signature packet found for signature")
+	}
 	signatureContext, err := findContext(sig.Notations)
 	if err != nil {
 		return err

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -215,15 +215,6 @@ func newSignatureFailed(cause error) SignatureVerificationError {
 	}
 }
 
-// newSignatureInsecure creates a new SignatureVerificationError, type
-// SignatureFailed, with a message describing the signature as insecure.
-func newSignatureInsecure() SignatureVerificationError {
-	return SignatureVerificationError{
-		Status:  constants.SIGNATURE_FAILED,
-		Message: "Insecure signature",
-	}
-}
-
 // newSignatureNotSigned creates a new SignatureVerificationError, type
 // SignatureNotSigned.
 func newSignatureNotSigned() SignatureVerificationError {


### PR DESCRIPTION
The hash rejection is handled by the lower level library `go-crypto`.