### PR TITLE
Add SHA3 to allowed signature hashes

### DIFF
--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -22,6 +22,8 @@ var allowedHashes = []crypto.Hash{
 	crypto.SHA256,
 	crypto.SHA384,
 	crypto.SHA512,
+	crypto.SHA3_256,
+	crypto.SHA3_512,
 }
 
 // SignatureVerificationError is returned from Decrypt and VerifyDetached

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/internal"
 )
 
+// allowedHashes stores the allowed OpenPGP hashes that can be used in a
+// message signature hash.
 var allowedHashes = []crypto.Hash{
 	crypto.SHA224,
 	crypto.SHA256,


### PR DESCRIPTION
Add SHA3 to the allowed signature hashes in GopenPGP v2.