### PR TITLE
Add decryption option to allow disabling the integrity tag requirement (#314)

### DIFF
--- a/crypto/decryption_core.go
+++ b/crypto/decryption_core.go
@@ -44,6 +44,7 @@ func (dh *decryptionHandle) decryptStream(encryptedMessage Reader) (plainMessage
 		checkIntendedRecipients := !dh.DisableIntendedRecipients
 		config.CheckIntendedRecipients = &checkIntendedRecipients
 	}
+	config.InsecureAllowUnauthenticatedMessages = dh.DisableUnauthenticatedMessagesCheck
 	if dh.VerifyKeyRing != nil {
 		entries = append(entries, dh.VerifyKeyRing.entities...)
 	}
@@ -167,6 +168,7 @@ func (dh *decryptionHandle) decryptStreamWithSessionAndParse(messageReader io.Re
 	checkPacketSequence := false
 	config.CheckIntendedRecipients = &checkIntendedRecipients
 	config.CheckPacketSequence = &checkPacketSequence
+	config.InsecureAllowUnauthenticatedMessages = dh.DisableUnauthenticatedMessagesCheck
 	md, err := openpgp.ReadMessage(decrypted, keyring, nil, config)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "gopenpgp: unable to decode symmetric packet")
@@ -294,6 +296,7 @@ func (dh *decryptionHandle) decryptStreamAndVerifyDetached(encryptedData, encryp
 	checkIntendedRecipients := !dh.DisableIntendedRecipients
 	config := dh.profile.EncryptionConfig()
 	config.CheckIntendedRecipients = &checkIntendedRecipients
+	config.InsecureAllowUnauthenticatedMessages = dh.DisableUnauthenticatedMessagesCheck
 
 	// Verifying reader that wraps the decryption readers to verify the signature
 	sigVerifyReader, err := verifyingDetachedReader(

--- a/crypto/decryption_handle.go
+++ b/crypto/decryption_handle.go
@@ -35,14 +35,15 @@ type decryptionHandle struct {
 	// DisableIntendedRecipients indicates if the signature verification should not check if
 	// the decryption key matches the intended recipients of the message.
 	// If disabled, the decryption throws no error in a non-matching case.
-	DisableIntendedRecipients    bool
-	DisableVerifyTimeCheck       bool
-	DisableStrictMessageParsing  bool
-	DisableAutomaticTextSanitize bool
-	RetrieveSessionKey           bool
-	IsUTF8                       bool
-	clock                        Clock
-	profile                      EncryptionProfile
+	DisableIntendedRecipients           bool
+	DisableVerifyTimeCheck              bool
+	DisableStrictMessageParsing         bool
+	DisableAutomaticTextSanitize        bool
+	DisableUnauthenticatedMessagesCheck bool
+	RetrieveSessionKey                  bool
+	IsUTF8                              bool
+	clock                               Clock
+	profile                             EncryptionProfile
 }
 
 // --- Default decryption handle to build from

--- a/crypto/decryption_handle_builder.go
+++ b/crypto/decryption_handle_builder.go
@@ -154,6 +154,20 @@ func (dpb *DecryptionHandleBuilder) DisableAutomaticTextSanitize() *DecryptionHa
 	return dpb
 }
 
+// DisableUnauthenticatedMessagesCheck enables to read
+// encrypted messages without Modification Detection Code (MDC).
+// MDC is mandated by the latest standard and has long been implemented
+// in most OpenPGP implementations. Messages without MDC are considered unnecessarily
+// insecure and should be prevented whenever possible.
+// In case one needs to deal with messages from very old OpenPGP implementations, there
+// might be no other way than to tolerate the missing MDC. Setting this flag, allows this
+// mode of operation. It should be considered a measure of last resort.
+// SECURITY HAZARD: Use with care.
+func (dpb *DecryptionHandleBuilder) DisableUnauthenticatedMessagesCheck() *DecryptionHandleBuilder {
+	dpb.handle.DisableUnauthenticatedMessagesCheck = true
+	return dpb
+}
+
 // RetrieveSessionKey sets the flag to indicate if the session key used for decryption
 // should be returned to the caller of the decryption function.
 func (dpb *DecryptionHandleBuilder) RetrieveSessionKey() *DecryptionHandleBuilder {


### PR DESCRIPTION
Allows to decrypt legacy messages that have no integrity protection. This option should be used with extreme care as it allows for downgrade attacks.