### PR TITLE
Add option to decrypt with signature keys

### DIFF
--- a/crypto/decryption_core.go
+++ b/crypto/decryption_core.go
@@ -341,11 +341,11 @@ func (dh *decryptionHandle) decryptionConfig(configTime int64) *packet.Config {
 	config.CheckPacketSequence = &checkPacketSequence
 
 	// Allow message decryption of PGP messages with no integrity tag.
-	config.InsecureAllowUnauthenticatedMessages = dh.DisableUnauthenticatedMessagesCheck
+	config.InsecureAllowUnauthenticatedMessages = dh.InsecureDisableUnauthenticatedMessagesCheck
 
 	// Allow message decryption with signature keys.
-	if dh.DisableNoSignatureKeyForDecryption {
-		config.InsecureAllowDecryptionWithSigningKeys = dh.DisableNoSignatureKeyForDecryption
+	if dh.InsecureAllowDecryptionWithSigningKeys {
+		config.InsecureAllowDecryptionWithSigningKeys = dh.InsecureAllowDecryptionWithSigningKeys
 	}
 
 	// Should the session key be returned.

--- a/crypto/decryption_core.go
+++ b/crypto/decryption_core.go
@@ -35,22 +35,16 @@ func NewPGPSplitReader(pgpMessage Reader, pgpEncryptedSignature Reader) *pgpSpli
 // decryptStream decrypts the stream either with the secret keys or a password.
 func (dh *decryptionHandle) decryptStream(encryptedMessage Reader) (plainMessage *VerifyDataReader, err error) {
 	var entries openpgp.EntityList
-	checkPacketSequence := !dh.DisableStrictMessageParsing
-	config := dh.profile.EncryptionConfig()
-	config.CacheSessionKey = dh.RetrieveSessionKey
-	config.CheckPacketSequence = &checkPacketSequence
+
+	config := dh.decryptionConfig(dh.clock().Unix())
 	if dh.DecryptionKeyRing != nil {
 		entries = dh.DecryptionKeyRing.entities
-		checkIntendedRecipients := !dh.DisableIntendedRecipients
-		config.CheckIntendedRecipients = &checkIntendedRecipients
 	}
-	config.InsecureAllowUnauthenticatedMessages = dh.DisableUnauthenticatedMessagesCheck
+
 	if dh.VerifyKeyRing != nil {
 		entries = append(entries, dh.VerifyKeyRing.entities...)
 	}
-	verifyTime := dh.clock().Unix()
 
-	config.Time = NewConstantClock(verifyTime)
 	if dh.VerificationContext != nil {
 		config.KnownNotations = map[string]bool{constants.SignatureContextName: true}
 	}
@@ -150,8 +144,9 @@ func (dh *decryptionHandle) decryptStreamWithSessionAndParse(messageReader io.Re
 		return nil, 0, errors.Wrap(err, "gopenpgp: unable to decrypt message with session key")
 	}
 
-	config := dh.profile.EncryptionConfig()
-	config.Time = NewConstantClock(dh.clock().Unix())
+	config := dh.decryptionConfig(dh.clock().Unix())
+	checkPacketSequence := false
+	config.CheckPacketSequence = &checkPacketSequence
 
 	if dh.VerificationContext != nil {
 		config.KnownNotations = map[string]bool{constants.SignatureContextName: true}
@@ -164,11 +159,6 @@ func (dh *decryptionHandle) decryptStreamWithSessionAndParse(messageReader io.Re
 	if dh.DecryptionKeyRing != nil {
 		keyring = append(keyring, dh.DecryptionKeyRing.entities...)
 	}
-	checkIntendedRecipients := !dh.DisableIntendedRecipients
-	checkPacketSequence := false
-	config.CheckIntendedRecipients = &checkIntendedRecipients
-	config.CheckPacketSequence = &checkPacketSequence
-	config.InsecureAllowUnauthenticatedMessages = dh.DisableUnauthenticatedMessagesCheck
 	md, err := openpgp.ReadMessage(decrypted, keyring, nil, config)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "gopenpgp: unable to decode symmetric packet")
@@ -244,11 +234,7 @@ func (dh *decryptionHandle) decryptStreamAndVerifyDetached(encryptedData, encryp
 		}
 	} else {
 		// Password or private keys
-		checkPacketSequence := !dh.DisableStrictMessageParsing
-		config := dh.profile.EncryptionConfig()
-		config.CacheSessionKey = dh.RetrieveSessionKey
-		config.Time = NewConstantClock(verifyTime)
-		config.CheckPacketSequence = &checkPacketSequence
+		config := dh.decryptionConfig(verifyTime)
 		var entries openpgp.EntityList
 		if dh.DecryptionKeyRing != nil {
 			entries = append(entries, dh.DecryptionKeyRing.entities...)
@@ -293,10 +279,7 @@ func (dh *decryptionHandle) decryptStreamAndVerifyDetached(encryptedData, encryp
 		}
 	}
 
-	checkIntendedRecipients := !dh.DisableIntendedRecipients
-	config := dh.profile.EncryptionConfig()
-	config.CheckIntendedRecipients = &checkIntendedRecipients
-	config.InsecureAllowUnauthenticatedMessages = dh.DisableUnauthenticatedMessagesCheck
+	config := dh.decryptionConfig(verifyTime)
 
 	// Verifying reader that wraps the decryption readers to verify the signature
 	sigVerifyReader, err := verifyingDetachedReader(
@@ -344,4 +327,31 @@ func createPasswordPrompt(password []byte) func(keys []openpgp.Key, symmetric bo
 		// For most (but not all) cases, inputting a wrong passwords is expected to trigger this error.
 		return nil, errors.New("gopenpgp: wrong password in symmetric decryption")
 	}
+}
+
+func (dh *decryptionHandle) decryptionConfig(configTime int64) *packet.Config {
+	config := dh.profile.EncryptionConfig()
+
+	// Check intended recipients in signatures.
+	checkIntendedRecipients := !dh.DisableIntendedRecipients
+	config.CheckIntendedRecipients = &checkIntendedRecipients
+
+	// Check for valid packet sequence
+	checkPacketSequence := !dh.DisableStrictMessageParsing
+	config.CheckPacketSequence = &checkPacketSequence
+
+	// Allow message decryption of PGP messages with no integrity tag.
+	config.InsecureAllowUnauthenticatedMessages = dh.DisableUnauthenticatedMessagesCheck
+
+	// Allow message decryption with signature keys.
+	if dh.DisableNoSignatureKeyForDecryption {
+		config.InsecureAllowDecryptionWithSigningKeys = dh.DisableNoSignatureKeyForDecryption
+	}
+
+	// Should the session key be returned.
+	config.CacheSessionKey = dh.RetrieveSessionKey
+
+	// Set time.
+	config.Time = NewConstantClock(configTime)
+	return config
 }

--- a/crypto/decryption_handle.go
+++ b/crypto/decryption_handle.go
@@ -40,6 +40,7 @@ type decryptionHandle struct {
 	DisableStrictMessageParsing         bool
 	DisableAutomaticTextSanitize        bool
 	DisableUnauthenticatedMessagesCheck bool
+	DisableNoSignatureKeyForDecryption  bool
 	RetrieveSessionKey                  bool
 	IsUTF8                              bool
 	clock                               Clock

--- a/crypto/decryption_handle.go
+++ b/crypto/decryption_handle.go
@@ -35,16 +35,16 @@ type decryptionHandle struct {
 	// DisableIntendedRecipients indicates if the signature verification should not check if
 	// the decryption key matches the intended recipients of the message.
 	// If disabled, the decryption throws no error in a non-matching case.
-	DisableIntendedRecipients           bool
-	DisableVerifyTimeCheck              bool
-	DisableStrictMessageParsing         bool
-	DisableAutomaticTextSanitize        bool
-	DisableUnauthenticatedMessagesCheck bool
-	DisableNoSignatureKeyForDecryption  bool
-	RetrieveSessionKey                  bool
-	IsUTF8                              bool
-	clock                               Clock
-	profile                             EncryptionProfile
+	DisableIntendedRecipients                   bool
+	DisableVerifyTimeCheck                      bool
+	DisableStrictMessageParsing                 bool
+	DisableAutomaticTextSanitize                bool
+	InsecureDisableUnauthenticatedMessagesCheck bool
+	InsecureAllowDecryptionWithSigningKeys      bool
+	RetrieveSessionKey                          bool
+	IsUTF8                                      bool
+	clock                                       Clock
+	profile                                     EncryptionProfile
 }
 
 // --- Default decryption handle to build from

--- a/crypto/decryption_handle_builder.go
+++ b/crypto/decryption_handle_builder.go
@@ -154,7 +154,7 @@ func (dpb *DecryptionHandleBuilder) DisableAutomaticTextSanitize() *DecryptionHa
 	return dpb
 }
 
-// DisableUnauthenticatedMessagesCheck enables to read
+// InsecureDisableUnauthenticatedMessagesCheck enables to read
 // encrypted messages without Modification Detection Code (MDC).
 // MDC is mandated by the latest standard and has long been implemented
 // in most OpenPGP implementations. Messages without MDC are considered unnecessarily
@@ -163,20 +163,20 @@ func (dpb *DecryptionHandleBuilder) DisableAutomaticTextSanitize() *DecryptionHa
 // might be no other way than to tolerate the missing MDC. Setting this flag, allows this
 // mode of operation. It should be considered a measure of last resort.
 // SECURITY HAZARD: Use with care.
-func (dpb *DecryptionHandleBuilder) DisableUnauthenticatedMessagesCheck() *DecryptionHandleBuilder {
-	dpb.handle.DisableUnauthenticatedMessagesCheck = true
+func (dpb *DecryptionHandleBuilder) InsecureDisableUnauthenticatedMessagesCheck() *DecryptionHandleBuilder {
+	dpb.handle.InsecureDisableUnauthenticatedMessagesCheck = true
 	return dpb
 }
 
-// AllowSignOnlyDecryptionKeys enables decryption of messages using keys
+// InsecureAllowDecryptionWithSigningKeys enables decryption of messages using keys
 // that are designated solely as signing keys.
 // While using the same key for both encryption and signing is discouraged
 // due to reduced security, this flag is useful for decrypting legacy messages.
 // This is because some older libraries did not respect key flags when
 // selecting a key for encryption.
 // SECURITY HAZARD: Use with care.
-func (dpb *DecryptionHandleBuilder) AllowSignOnlyDecryptionKeys() *DecryptionHandleBuilder {
-	dpb.handle.DisableNoSignatureKeyForDecryption = true
+func (dpb *DecryptionHandleBuilder) InsecureAllowDecryptionWithSigningKeys() *DecryptionHandleBuilder {
+	dpb.handle.InsecureAllowDecryptionWithSigningKeys = true
 	return dpb
 }
 

--- a/crypto/decryption_handle_builder.go
+++ b/crypto/decryption_handle_builder.go
@@ -168,6 +168,18 @@ func (dpb *DecryptionHandleBuilder) DisableUnauthenticatedMessagesCheck() *Decry
 	return dpb
 }
 
+// AllowSignOnlyDecryptionKeys enables decryption of messages using keys
+// that are designated solely as signing keys.
+// While using the same key for both encryption and signing is discouraged
+// due to reduced security, this flag is useful for decrypting legacy messages.
+// This is because some older libraries did not respect key flags when
+// selecting a key for encryption.
+// SECURITY HAZARD: Use with care.
+func (dpb *DecryptionHandleBuilder) AllowSignOnlyDecryptionKeys() *DecryptionHandleBuilder {
+	dpb.handle.DisableNoSignatureKeyForDecryption = true
+	return dpb
+}
+
 // RetrieveSessionKey sets the flag to indicate if the session key used for decryption
 // should be returned to the caller of the decryption function.
 func (dpb *DecryptionHandleBuilder) RetrieveSessionKey() *DecryptionHandleBuilder {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ProtonMail/gopenpgp/v3
 go 1.17
 
 require (
-	github.com/ProtonMail/go-crypto v1.1.2
+	github.com/ProtonMail/go-crypto v1.1.3
 	github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ProtonMail/go-crypto v1.1.2 h1:A7JbD57ThNqh7XjmHE+PXpQ3Dqt3BrSAC0AL0Go3KS0=
-github.com/ProtonMail/go-crypto v1.1.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
+github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f h1:tCbYj7/299ekTTXpdwKYF8eBlsYsDVoggDAuAjoK66k=
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f/go.mod h1:gcr0kNtGBqin9zDW9GOHcVntrwnjrK+qdJ06mWYBybw=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -46,10 +46,10 @@ type Custom struct {
 	AllowAllPublicKeyAlgorithms bool
 	// DisableIntendedRecipients is a flag to disable the intended recipients pgp feature from the crypto-refresh.
 	DisableIntendedRecipients bool
-	// AllowWeakRSA is a flag to disable checks for weak rsa keys.
-	AllowWeakRSA bool
-	// AllowSingingKeyInDecryption is a flag to enable to decrypt with signing keys for compatibility reasons.
-	AllowSingingKeyInDecryption bool
+	// InsecureAllowWeakRSA is a flag to disable checks for weak rsa keys.
+	InsecureAllowWeakRSA bool
+	// InsecureAllowDecryptionWithSigningKeys is a flag to enable to decrypt with signing keys for compatibility reasons.
+	InsecureAllowDecryptionWithSigningKeys bool
 }
 
 // Custom implements the profile interfaces:
@@ -74,7 +74,7 @@ func (p *Custom) EncryptionConfig() *packet.Config {
 		DefaultCipher:                          p.CipherEncryption,
 		AEADConfig:                             p.AeadEncryption,
 		S2KConfig:                              p.S2kEncryption,
-		InsecureAllowDecryptionWithSigningKeys: p.AllowSingingKeyInDecryption,
+		InsecureAllowDecryptionWithSigningKeys: p.InsecureAllowDecryptionWithSigningKeys,
 	}
 	if p.DisableIntendedRecipients {
 		intendedRecipients := false
@@ -83,7 +83,7 @@ func (p *Custom) EncryptionConfig() *packet.Config {
 	if p.AllowAllPublicKeyAlgorithms {
 		config.RejectPublicKeyAlgorithms = map[packet.PublicKeyAlgorithm]bool{}
 	}
-	if p.AllowWeakRSA {
+	if p.InsecureAllowWeakRSA {
 		config.MinRSABits = weakMinRSABits
 	}
 	return config
@@ -112,7 +112,7 @@ func (p *Custom) SignConfig() *packet.Config {
 	if p.AllowAllPublicKeyAlgorithms {
 		config.RejectPublicKeyAlgorithms = map[packet.PublicKeyAlgorithm]bool{}
 	}
-	if p.AllowWeakRSA {
+	if p.InsecureAllowWeakRSA {
 		config.MinRSABits = weakMinRSABits
 	}
 	return config

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -48,6 +48,8 @@ type Custom struct {
 	DisableIntendedRecipients bool
 	// AllowWeakRSA is a flag to disable checks for weak rsa keys.
 	AllowWeakRSA bool
+	// AllowSingingKeyInDecryption is a flag to enable to decrypt with signing keys for compatibility reasons.
+	AllowSingingKeyInDecryption bool
 }
 
 // Custom implements the profile interfaces:
@@ -68,10 +70,11 @@ func (p *Custom) KeyGenerationConfig(securityLevel int8) *packet.Config {
 
 func (p *Custom) EncryptionConfig() *packet.Config {
 	config := &packet.Config{
-		DefaultHash:   p.Hash,
-		DefaultCipher: p.CipherEncryption,
-		AEADConfig:    p.AeadEncryption,
-		S2KConfig:     p.S2kEncryption,
+		DefaultHash:                            p.Hash,
+		DefaultCipher:                          p.CipherEncryption,
+		AEADConfig:                             p.AeadEncryption,
+		S2KConfig:                              p.S2kEncryption,
+		InsecureAllowDecryptionWithSigningKeys: p.AllowSingingKeyInDecryption,
 	}
 	if p.DisableIntendedRecipients {
 		intendedRecipients := false


### PR DESCRIPTION
- Updates go-crypto to `v1.1.3`
- Refactors config handling in decryption by de-duplicating code
- Add option in decryption to allow to decrypt with signature keys for legacy reasons.