### PR TITLE
feat: Improve API for Encryption with a session key

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -73,7 +73,9 @@ func (p *PGPHandle) LockKey(key *Key, passphrase []byte) (*Key, error) {
 }
 
 // GenerateSessionKey generates a random session key for the profile.
+// Use GenerateSessionKey on the encryption handle, if the PGP encryption keys are known.
+// This function only considers the profile to determine the session key type.
 func (p *PGPHandle) GenerateSessionKey() (*SessionKey, error) {
 	config := p.profile.EncryptionConfig()
-	return generateSessionKey(config)
+	return generateSessionKey(config, nil, nil)
 }

--- a/crypto/decryption_core.go
+++ b/crypto/decryption_core.go
@@ -191,7 +191,7 @@ Loop:
 				}
 			}
 			var dc packet.CipherFunction
-			if !sessionKey.v6 {
+			if sessionKey.hasAlgorithm() {
 				dc, err = sessionKey.GetCipherFunc()
 				if err != nil {
 					return nil, errors.Wrap(err, "gopenpgp: unable to decrypt with session key")

--- a/crypto/encryption.go
+++ b/crypto/encryption.go
@@ -23,6 +23,9 @@ type PGPEncryption interface {
 	// EncryptSessionKey encrypts a session key with the encryption handle.
 	// To encrypt a session key, the handle must contain either recipients or a password.
 	EncryptSessionKey(sessionKey *SessionKey) ([]byte, error)
+	// GenerateSessionKey generates a random session key for the given encryption handle
+	// considering the algorithm preferences of the recipient keys.
+	GenerateSessionKey() (*SessionKey, error)
 	// ClearPrivateParams clears all private key material contained in EncryptionHandle from memory.
 	ClearPrivateParams()
 }

--- a/crypto/encryption_handle.go
+++ b/crypto/encryption_handle.go
@@ -131,6 +131,14 @@ func (eh *encryptionHandle) EncryptSessionKey(sessionKey *SessionKey) ([]byte, e
 	return nil, errors.New("gopenpgp: no password or recipients in encryption handle")
 }
 
+// GenerateSessionKey generates a random session key for the given encryption handle
+// considering the algorithm preferences of the recipient keys.
+func (eh *encryptionHandle) GenerateSessionKey() (*SessionKey, error) {
+	config := eh.profile.EncryptionConfig()
+	config.Time = NewConstantClock(eh.clock().Unix())
+	return generateSessionKey(config, eh.Recipients, eh.HiddenRecipients)
+}
+
 // --- Helper methods on encryption handle
 
 func (eh *encryptionHandle) validate() error {


### PR DESCRIPTION
With RFC 9580, clients can encrypt data using AEAD with SEIPDv2 packets. However, SEIPDv2 packets are only compatible with PKESK v6 and SKESK v6 packets when the session key is encrypted using an OpenPGP certificate.

This PR improves the API to reduce the risk of encrypting data with SEIPDv2 while using a session key encrypted in a packet version below v6. Specifically, the session key now includes an indicator of whether it is intended for AEAD use or not and affects the produced packets.