### PR TITLE
Update go-crypto to 1.3.0

### DIFF
--- a/crypto/decryption_core.go
+++ b/crypto/decryption_core.go
@@ -352,6 +352,11 @@ func (dh *decryptionHandle) decryptionConfig(configTime int64) *packet.Config {
 	// Should the session key be returned.
 	config.CacheSessionKey = dh.RetrieveSessionKey
 
+	// Set max decompression size if set.
+	if dh.MaxDecompressedSize != 0 {
+		config.MaxDecompressedMessageSize = &dh.MaxDecompressedSize
+	}
+
 	// Set time.
 	config.Time = NewConstantClock(configTime)
 	return config

--- a/crypto/decryption_handle.go
+++ b/crypto/decryption_handle.go
@@ -30,6 +30,9 @@ type decryptionHandle struct {
 	// VerificationContext provides a verification context for the signature of the pgp message, if any.
 	// Only considered if VerifyKeyRing is not nil.
 	VerificationContext *VerificationContext
+	// MaxDecompressedSize defines the maximum number of bytes allowed for a message
+	// after decompression. An error is thrown if the decompressed data exceeds this limit.
+	MaxDecompressedSize int64
 	// PlainDetachedSignature indicates that all provided detached signatures are not encrypted.
 	PlainDetachedSignature bool
 	// DisableIntendedRecipients indicates if the signature verification should not check if

--- a/crypto/decryption_handle_builder.go
+++ b/crypto/decryption_handle_builder.go
@@ -123,6 +123,13 @@ func (dpb *DecryptionHandleBuilder) PlainDetachedSignature() *DecryptionHandleBu
 	return dpb
 }
 
+// MaxDecompressedMessageSize defines the maximum number of bytes allowed for a message
+// after decompression. An error is thrown if the decompressed data exceeds this limit.
+func (dpb *DecryptionHandleBuilder) MaxDecompressedMessageSize(size int64) *DecryptionHandleBuilder {
+	dpb.handle.MaxDecompressedSize = size
+	return dpb
+}
+
 // DisableVerifyTimeCheck disables the check for comparing the signature creation time
 // against the verification time.
 func (dpb *DecryptionHandleBuilder) DisableVerifyTimeCheck() *DecryptionHandleBuilder {

--- a/crypto/verify_handle.go
+++ b/crypto/verify_handle.go
@@ -17,6 +17,7 @@ import (
 type verifyHandle struct {
 	VerifyKeyRing                *KeyRing
 	VerificationContext          *VerificationContext
+	MaxDecompressedSize          int64
 	DisableVerifyTimeCheck       bool
 	DisableStrictMessageParsing  bool
 	DisableAutomaticTextSanitize bool
@@ -161,6 +162,9 @@ func (vh *verifyHandle) verifyingReader(
 	config.CheckPacketSequence = &checkPacketSequence
 	verifyTime := vh.clock().Unix()
 	config.Time = NewConstantClock(verifyTime)
+	if vh.MaxDecompressedSize != 0 {
+		config.MaxDecompressedMessageSize = &vh.MaxDecompressedSize
+	}
 	if vh.VerificationContext != nil {
 		config.KnownNotations = map[string]bool{constants.SignatureContextName: true}
 	}

--- a/crypto/verify_handle_builder.go
+++ b/crypto/verify_handle_builder.go
@@ -80,6 +80,14 @@ func (vhb *VerifyHandleBuilder) DisableAutomaticTextSanitize() *VerifyHandleBuil
 	return vhb
 }
 
+// MaxDecompressedMessageSize specifies the maximum allowed size, in bytes,
+// for a message after decompression within an inline-signed message.
+// If the decompressed message exceeds this limit, an error is returned.
+func (vhb *VerifyHandleBuilder) MaxDecompressedMessageSize(size int64) *VerifyHandleBuilder {
+	vhb.handle.MaxDecompressedSize = size
+	return vhb
+}
+
 // New creates a VerifyHandle and checks that the given
 // combination of parameters is valid. If the parameters are invalid,
 // an error is returned.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ProtonMail/gopenpgp/v3
 go 1.22.0
 
 require (
-	github.com/ProtonMail/go-crypto v1.2.0
+	github.com/ProtonMail/go-crypto v1.3.0
 	github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ProtonMail/go-crypto v1.2.0 h1:+PhXXn4SPGd+qk76TlEePBfOfivE0zkWFenhGhFLzWs=
-github.com/ProtonMail/go-crypto v1.2.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
+github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
+github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f h1:tCbYj7/299ekTTXpdwKYF8eBlsYsDVoggDAuAjoK66k=
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f/go.mod h1:gcr0kNtGBqin9zDW9GOHcVntrwnjrK+qdJ06mWYBybw=
 github.com/cloudflare/circl v1.6.0 h1:cr5JKic4HI+LkINy2lg3W2jF8sHCVTBncJr5gIIq7qk=

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -50,6 +50,9 @@ type Custom struct {
 	InsecureAllowWeakRSA bool
 	// InsecureAllowDecryptionWithSigningKeys is a flag to enable to decrypt with signing keys for compatibility reasons.
 	InsecureAllowDecryptionWithSigningKeys bool
+	// MaxDecompressedMessageSize sets the maximum decompressed messages size that can be read
+	// before throwing an error.
+	MaxDecompressedMessageSize int64
 }
 
 // Custom implements the profile interfaces:
@@ -75,6 +78,7 @@ func (p *Custom) EncryptionConfig() *packet.Config {
 		AEADConfig:                             p.AeadEncryption,
 		S2KConfig:                              p.S2kEncryption,
 		InsecureAllowDecryptionWithSigningKeys: p.InsecureAllowDecryptionWithSigningKeys,
+		MaxDecompressedMessageSize:             p.maxDecompressedMessageSize(),
 	}
 	if p.DisableIntendedRecipients {
 		intendedRecipients := false
@@ -100,7 +104,8 @@ func (p *Custom) KeyEncryptionConfig() *packet.Config {
 
 func (p *Custom) SignConfig() *packet.Config {
 	config := &packet.Config{
-		DefaultHash: p.Hash,
+		DefaultHash:                p.Hash,
+		MaxDecompressedMessageSize: p.maxDecompressedMessageSize(),
 	}
 	if p.SignHash != nil {
 		config.DefaultHash = *p.SignHash
@@ -123,4 +128,11 @@ func (p *Custom) CompressionConfig() *packet.Config {
 		CompressionConfig:      p.CompressionConfiguration,
 		DefaultCompressionAlgo: p.CompressionAlgorithm,
 	}
+}
+
+func (p *Custom) maxDecompressedMessageSize() *int64 {
+	if p.MaxDecompressedMessageSize == 0 {
+		return nil
+	}
+	return &p.MaxDecompressedMessageSize
 }


### PR DESCRIPTION
Additionally, it introduces the option to specify a limit on the amount of data that can be extracted from compressed input.