### PR TITLE
feat: add GetFingerprints & GetJsonFingerprints for primary and sub keys

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -392,6 +392,20 @@ func (key *Key) GetFingerprintBytes() []byte {
 	return key.entity.PrimaryKey.Fingerprint
 }
 
+// GetFingerprints returns SHA-1 fingerprints of the primary key and its subkeys.
+func (key *Key) GetFingerprints() (fingerprints []string) {
+	fingerprints = append(fingerprints, hex.EncodeToString(key.entity.PrimaryKey.Fingerprint))
+	for _, sub := range key.entity.Subkeys {
+		fingerprints = append(fingerprints, hex.EncodeToString(sub.PublicKey.Fingerprint))
+	}
+	return fingerprints
+}
+
+// GetJsonFingerprints returns the same data as JSON (for gomobile).
+func (key *Key) GetJsonFingerprints() ([]byte, error) {
+     return json.Marshal(key.GetFingerprints)
+}
+
 // GetSHA256Fingerprint computes the SHA256 fingerprint of the primary key.
 func (key *Key) GetSHA256Fingerprint() (fingerprint string) {
 	return hex.EncodeToString(getSHA256FingerprintBytes(key.entity.PrimaryKey))

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -346,6 +346,19 @@ func TestGetSHA256FingerprintsV4(t *testing.T) {
 	assert.Exactly(t, "d9ac0b857da6d2c8be985b251a9e3db31e7a1d2d832d1f07ebe838a9edce9c24", publicKey.GetSHA256Fingerprint())
 }
 
+func TestGetFingerprints(t *testing.T) {
+	publicKey, err := NewKeyFromArmored(readTestFile("keyring_publicKey", false))
+	if err != nil {
+		t.Fatal("Cannot unarmor key:", err)
+	}
+
+	allFingerprints := publicKey.GetFingerprints()
+
+	assert.Len(t, allFingerprints, 2)
+	assert.Exactly(t, "6e8ba229b0cccaf6962f97953eb6259edf21df24", allFingerprints[0])
+	assert.Exactly(t, "37e4bcf09b36e34012d10c0247dc67b5cb8267f6", allFingerprints[1])
+}
+
 func TestGetEntity(t *testing.T) {
 	publicKey, err := NewKeyFromArmored(readTestFile("keyring_publicKey", false))
 	if err != nil {


### PR DESCRIPTION
* **GetFingerprints() []string**
  * Returns SHA-1 fingerprints of primary key and all subkeys.

* **GetJsonFingerprints() (string, error)**
  * Same data, JSON-encoded for gomobile bind where slice-of-string
    is not always stable across language bindings.

This allows apps to list every fingerprint including subkeys
 without re-implementing the walk logic outside the library.

Unit test included (crypto/key_test.go).