### PR TITLE
fix: correct typos in comments and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.7.0] 2023-04-14
 ### Changed
-- The `SignatureVerificationError` struct now has a `Cause error` field, which is returned by the the Unwrap function. The cause is also included in the error message.
+- The `SignatureVerificationError` struct now has a `Cause error` field, which is returned by the Unwrap function. The cause is also included in the error message.
 	NB: If the caller was relying on the exact message of the error, it might break the flow.
 - When a signature fails verification because of the signature context, it returns a `SignatureVerificationError` with 
 status `constants.SIGNATURE_BAD_CONTEXT` instead of `constants.SIGNATURE_FAILED`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -786,7 +786,7 @@ This version comes with some design improvements, in particular the introduction
 - `Signature#KeyRing` function
 - `Signature#IsBy` function
 - `pmKeyObject` struct
-- `encodedLength` function, internal and and unused
+- `encodedLength` function, internal and unused
 - `EncryptCore` is now internal.
 - `RandomTokenWith`, `RandomToken` now takes a size
 - In the `KeyRing` struct:

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -32,7 +32,7 @@ type Custom struct {
 	// Hash defines hash algorithm to be used.
 	Hash crypto.Hash
 	// SignHash defines if a different hash algorithm should be used for signing.
-	// If nil, the a above field Hash is used.
+	// If nil, the above field Hash is used.
 	SignHash *crypto.Hash
 	// CipherKeyEncryption defines the cipher to be used for key encryption.
 	CipherKeyEncryption packet.CipherFunction


### PR DESCRIPTION
Fix three minor typos found in comments and the changelog:

- Remove duplicate "the" in CHANGELOG
- Remove duplicate "and" in CHANGELOG
- Remove extra "a" in `profile/profile.go`